### PR TITLE
allow `clippy::identity_op` to avoid clippy warnings

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -109,6 +109,7 @@ pub mod fee {
 }
 
 /// The number of blocks in one session
+#[allow(clippy::identity_op)]
 pub const SESSION_PERIOD_BLOCKS: BlockNumber = 1 * crate::time::HOURS;
 
 /// We assume that ~10% of the block weight is consumed by `on_initialize` handlers.


### PR DESCRIPTION
it does not affect the actual result of the code, but more of easier readability in this case.