### PR TITLE
[fix] use 18 decimal places in chainspec

### DIFF
--- a/node/src/chain_spec/mod.rs
+++ b/node/src/chain_spec/mod.rs
@@ -163,7 +163,7 @@ pub fn development_config(id: ParaId) -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "tTNT".into());
-	properties.insert("tokenDecimals".into(), 12u32.into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
 	properties.insert("ss58Format".into(), 42.into());
 
 	ChainSpec::from_genesis(
@@ -234,7 +234,7 @@ pub fn local_testnet_config(id: ParaId) -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "tTNT".into());
-	properties.insert("tokenDecimals".into(), 12u32.into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
 	properties.insert("ss58Format".into(), 42.into());
 
 	ChainSpec::from_genesis(
@@ -306,7 +306,7 @@ pub fn tangle_minerva_config(id: ParaId) -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "tTNT".into());
-	properties.insert("tokenDecimals".into(), 12u32.into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
 	properties.insert("ss58Format".into(), 42.into());
 
 	ChainSpec::from_genesis(

--- a/node/src/chain_spec/rococo.rs
+++ b/node/src/chain_spec/rococo.rs
@@ -28,7 +28,7 @@ pub fn tangle_alpha_config(id: ParaId) -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "TNT".into());
-	properties.insert("tokenDecimals".into(), 12u32.into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
 	properties.insert("ss58Format".into(), 42.into());
 
 	ChainSpec::from_genesis(
@@ -98,7 +98,7 @@ pub fn tangle_rococo_config(id: ParaId) -> ChainSpec {
 	// Give your base currency a unit name and decimal places
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "TNT".into());
-	properties.insert("tokenDecimals".into(), 12u32.into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
 	properties.insert("ss58Format".into(), 42.into());
 
 	ChainSpec::from_genesis(


### PR DESCRIPTION
Changelog:
- Update to use 18 decimal places in chainspec, rest of the runtime already use 18