### PR TITLE
Update Native Asset name and its Id

### DIFF
--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -523,15 +523,16 @@ fn testnet_genesis(
 		grandpa: Default::default(),
 		dkg: DKGConfig {
 			authorities: initial_authorities.iter().map(|(.., x)| x.clone()).collect::<_>(),
-			keygen_threshold: 5,
-			signature_threshold: 3,
+			keygen_threshold: initial_authorities.len() as u16,
+			// 2/3 of the authorities to the nearest integer.
+			signature_threshold: core::cmp::max((initial_authorities.len() as u16 * 2) / 3, 1),
 			authority_ids: initial_authorities.iter().map(|(x, ..)| x.clone()).collect::<_>(),
 		},
 		dkg_proposals: DKGProposalsConfig { initial_chain_ids, initial_r_ids, initial_proposers },
 		bridge_registry: Default::default(),
 		asset_registry: AssetRegistryConfig {
 			asset_names: vec![],
-			native_asset_name: b"WEBB".to_vec().try_into().unwrap(),
+			native_asset_name: b"tTNT".to_vec().try_into().unwrap(),
 			native_existential_deposit: tangle_runtime::EXISTENTIAL_DEPOSIT,
 		},
 		hasher_bn_254: HasherBn254Config {

--- a/standalone/node/src/chain_spec.rs
+++ b/standalone/node/src/chain_spec.rs
@@ -91,6 +91,11 @@ fn dkg_session_keys(
 pub fn development_config() -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
 
+	let mut properties = sc_chain_spec::Properties::new();
+	properties.insert("tokenSymbol".into(), "dTNT".into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
+	properties.insert("ss58Format".into(), 42.into());
+
 	Ok(ChainSpec::from_genesis(
 		// Name
 		"Development",
@@ -144,7 +149,7 @@ pub fn development_config() -> Result<ChainSpec, String> {
 		// Fork id
 		None,
 		// Properties
-		None,
+		Some(properties),
 		// Extensions
 		None,
 	))
@@ -152,6 +157,10 @@ pub fn development_config() -> Result<ChainSpec, String> {
 
 pub fn local_testnet_config() -> Result<ChainSpec, String> {
 	let wasm_binary = WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?;
+	let mut properties = sc_chain_spec::Properties::new();
+	properties.insert("tokenSymbol".into(), "tTNT".into());
+	properties.insert("tokenDecimals".into(), 18u32.into());
+	properties.insert("ss58Format".into(), 42.into());
 
 	Ok(ChainSpec::from_genesis(
 		// Name
@@ -167,8 +176,6 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 					authority_keys_from_seed("Alice", "Alice//stash"),
 					authority_keys_from_seed("Bob", "Bob//stash"),
 					authority_keys_from_seed("Charlie", "Charlie//stash"),
-					authority_keys_from_seed("Dave", "Dave//stash"),
-					authority_keys_from_seed("Eve", "Eve//stash"),
 				],
 				vec![],
 				// Sudo account
@@ -209,7 +216,7 @@ pub fn local_testnet_config() -> Result<ChainSpec, String> {
 		// Fork id
 		None,
 		// Properties
-		None,
+		Some(properties),
 		// Extensions
 		None,
 	))

--- a/standalone/runtime/src/protocol_substrate_config.rs
+++ b/standalone/runtime/src/protocol_substrate_config.rs
@@ -113,16 +113,20 @@ impl pallet_token_wrapper::Config for Runtime {
 }
 
 parameter_types! {
+	pub const NativeCurrencyId: webb_primitives::AssetId = 0;
+}
+
+parameter_types! {
 	#[derive(Copy, Clone, Debug, PartialEq, Eq, scale_info::TypeInfo)]
 	pub const MaxAssetIdInPool: u32 = 100;
 }
 
 impl pallet_asset_registry::Config for Runtime {
 	type AssetId = webb_primitives::AssetId;
-	type AssetNativeLocation = u32;
+	type AssetNativeLocation = ();
 	type Balance = Balance;
 	type RuntimeEvent = RuntimeEvent;
-	type NativeAssetId = GetNativeCurrencyId;
+	type NativeAssetId = NativeCurrencyId;
 	type MaxAssetIdInPool = MaxAssetIdInPool;
 	type RegistryOrigin = frame_system::EnsureRoot<AccountId>;
 	type StringLimit = RegistryStringLimit;
@@ -130,6 +134,7 @@ impl pallet_asset_registry::Config for Runtime {
 }
 
 pub type ReserveIdentifier = [u8; 8];
+
 impl orml_tokens::Config for Runtime {
 	type Amount = Amount;
 	type Balance = Balance;
@@ -144,16 +149,13 @@ impl orml_tokens::Config for Runtime {
 	type CurrencyHooks = ();
 }
 
-parameter_types! {
-	pub const GetNativeCurrencyId: webb_primitives::AssetId = 0;
-}
-
 pub type NativeCurrency = NativeCurrencyOf<Runtime>;
-pub type AdaptedBasicCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, Balance>;
+pub type AdaptedBasicCurrency = BasicCurrencyAdapter<Runtime, Balances, Amount, Moment>;
+
 impl orml_currencies::Config for Runtime {
 	type MultiCurrency = Tokens;
 	type NativeCurrency = AdaptedBasicCurrency;
-	type GetNativeCurrencyId = GetNativeCurrencyId;
+	type GetNativeCurrencyId = NativeCurrencyId;
 	type WeightInfo = ();
 }
 
@@ -165,7 +167,7 @@ parameter_types! {
 impl pallet_mixer::Config<pallet_mixer::Instance1> for Runtime {
 	type Currency = Currencies;
 	type RuntimeEvent = RuntimeEvent;
-	type NativeCurrencyId = GetNativeCurrencyId;
+	type NativeCurrencyId = NativeCurrencyId;
 	type PalletId = MixerPalletId;
 	type Tree = MerkleTreeBn254;
 	type Verifier = MixerVerifierBn254;
@@ -275,7 +277,7 @@ impl pallet_vanchor::Config<pallet_vanchor::Instance1> for Runtime {
 	type MaxFee = MaxFee;
 	type MaxExtAmount = MaxExtAmount;
 	type PostDepositHook = ();
-	type NativeCurrencyId = GetNativeCurrencyId;
+	type NativeCurrencyId = NativeCurrencyId;
 	type MaxCurrencyId = MaxCurrencyId;
 	type TokenWrapper = TokenWrapper;
 	type WeightInfo = ();


### PR DESCRIPTION
### Changes

- rename the native asset from "WEBB" to "tTNT".
- add system propitiates to test chain specs.
- update `keygen_threshold = authorities.len()` by default.
- update `signature_threshold = (2 / 3) *  authorities.len()` by default.
- update `AdaptedBasicCurrency` to be the correct type.