### PR TITLE
Fix docker build for integration-testing

### DIFF
--- a/docker/Tangle.Dockerfile
+++ b/docker/Tangle.Dockerfile
@@ -50,5 +50,3 @@ COPY --from=builder /tangle/target/release/${BINARY} /
 
 EXPOSE 30333 9933 9944 9615
 VOLUME ["/data"]
-ENTRYPOINT ./${BINARY} -d /data
-CMD ./${BINARY}


### PR DESCRIPTION
## Overview
Blocks are not produced using the current `Tangle.Dockerfile` for integration-test build.