### PR TITLE
Fix libgmp Linking issue with nix setup.

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,8 +48,9 @@
             toolchain
           ];
           packages = [ ];
+          # Environment variables
+          RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
+          LD_LIBRARY_PATH = "${pkgs.gmp}/lib";
         };
-        # Environment variables
-        RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";
       });
 }


### PR DESCRIPTION
This a small PR that fixes the issue of linking libgmp while using Nix to setup your local Env.