### PR TITLE
Update EVM Transaction Base Fee

### DIFF
--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -82,6 +82,12 @@ pub mod currency {
 	#[cfg(not(feature = "integration-tests"))]
 	pub const EXISTENTIAL_DEPOSIT: Balance = 10 * CENT;
 
+	pub const WEI: Balance = 1;
+	pub const KILOWEI: Balance = 1_000;
+	pub const MEGAWEI: Balance = 1_000_000;
+	pub const GIGAWEI: Balance = 1_000_000_000;
+	// 0.1 GWei
+	pub const WEIGHT_FEE: Balance = 100 * MEGAWEI;
 	/// Return the cost to add an item to storage based on size
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 20 * DOLLAR + (bytes as Balance) * 100 * MILLICENT

--- a/standalone/runtime/src/frontier_evm.rs
+++ b/standalone/runtime/src/frontier_evm.rs
@@ -19,12 +19,16 @@ use crate::{
 	precompiles::{PrecompileName, WebbPrecompiles},
 	*,
 };
-use frame_support::{pallet_prelude::*, parameter_types, traits::FindAuthor, weights::Weight};
+use frame_support::{
+	pallet_prelude::*,
+	parameter_types,
+	traits::FindAuthor,
+	weights::{constants::WEIGHT_REF_TIME_PER_SECOND, Weight},
+};
 use sp_core::{crypto::ByteArray, H160, U256};
 use sp_runtime::{traits::BlakeTwo256, ConsensusEngineId, Permill};
 use sp_std::{marker::PhantomData, prelude::*};
 // Frontier
-use fp_evm::weight_per_gas;
 use pallet_ethereum::PostLogContent;
 use pallet_evm::HashedAddressMapping;
 
@@ -104,14 +108,34 @@ impl pallet_evm_precompile_proxy::EvmProxyCallFilter for ProxyType {
 	}
 }
 
-const BLOCK_GAS_LIMIT: u64 = 75_000_000;
-const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+/// Current approximation of the gas/s consumption considering
+/// EVM execution over compiled WASM (on 4.4Ghz CPU).
+/// Given the 500ms Weight, from which 75% only are used for transactions,
+/// the total EVM execution gas limit is: GAS_PER_SECOND * 0.500 * 0.75 ~= 15_000_000.
+pub const GAS_PER_SECOND: u64 = 40_000_000;
+
+/// Approximate ratio of the amount of Weight per Gas.
+/// u64 works for approximations because Weight is a very small unit compared to gas.
+pub const WEIGHT_PER_GAS: u64 = WEIGHT_REF_TIME_PER_SECOND / GAS_PER_SECOND;
+
+const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
+// Here we assume Ethereum's base fee of 21000 gas and convert to weight, but we
+// subtract roughly the cost of a balance transfer from it (about 1/3 the cost)
+// and some cost to account for per-byte-fee.
+// TODO: we should use benchmarking's overhead feature to measure this
+pub const EXTRINSIC_BASE_WEIGHT: Weight = Weight::from_parts(10000 * WEIGHT_PER_GAS, 0);
 
 parameter_types! {
-	pub BlockGasLimit: U256 = U256::from(BLOCK_GAS_LIMIT);
-	pub const GasLimitPovSizeRatio: u64 = BLOCK_GAS_LIMIT.saturating_div(MAX_POV_SIZE);
+	pub BlockGasLimit: U256
+		= U256::from(NORMAL_DISPATCH_RATIO * MAXIMUM_BLOCK_WEIGHT.ref_time() / WEIGHT_PER_GAS);
+	/// The amount of gas per pov. A ratio of 4 if we convert ref_time to gas and we compare
+	/// it with the pov_size for a block. E.g.
+	/// ceil(
+	///     (max_extrinsic.ref_time() / max_extrinsic.proof_size()) / WEIGHT_PER_GAS
+	/// )
+	pub const GasLimitPovSizeRatio: u64 = 4;
+	pub WeightPerGas: Weight = Weight::from_parts(WEIGHT_PER_GAS, 0);
 	pub PrecompilesValue: WebbPrecompiles<Runtime> = WebbPrecompiles::<_>::new();
-	pub WeightPerGas: Weight = Weight::from_parts(weight_per_gas(BLOCK_GAS_LIMIT, NORMAL_DISPATCH_RATIO, WEIGHT_MILLISECS_PER_BLOCK), 0);
 }
 
 impl pallet_evm::Config for Runtime {
@@ -158,8 +182,9 @@ impl pallet_dynamic_fee::Config for Runtime {
 }
 
 parameter_types! {
-	pub DefaultBaseFeePerGas: U256 = U256::from(1_000_000_000);
-	pub DefaultElasticity: Permill = Permill::from_parts(125_000);
+	pub DefaultBaseFeePerGas: U256 = U256::from(WEIGHT_FEE);
+	// 1.5%
+	pub DefaultElasticity: Permill = Permill::from_parts(15_000);
 }
 
 pub struct BaseFeeThreshold;
@@ -168,10 +193,10 @@ impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
 		Permill::zero()
 	}
 	fn ideal() -> Permill {
-		Permill::from_parts(500_000)
+		Permill::from_parts(100_000)
 	}
 	fn upper() -> Permill {
-		Permill::from_parts(1_000_000)
+		Permill::from_parts(250_000)
 	}
 }
 

--- a/standalone/runtime/src/frontier_evm.rs
+++ b/standalone/runtime/src/frontier_evm.rs
@@ -183,8 +183,8 @@ impl pallet_dynamic_fee::Config for Runtime {
 
 parameter_types! {
 	pub DefaultBaseFeePerGas: U256 = U256::from(WEIGHT_FEE);
-	// 1.5%
-	pub DefaultElasticity: Permill = Permill::from_parts(15_000);
+	// No Elasticity, so the base fee will be constant.
+	pub DefaultElasticity: Permill = Permill::from_parts(0);
 }
 
 pub struct BaseFeeThreshold;
@@ -193,10 +193,10 @@ impl pallet_base_fee::BaseFeeThreshold for BaseFeeThreshold {
 		Permill::zero()
 	}
 	fn ideal() -> Permill {
-		Permill::from_parts(100_000)
+		Permill::zero()
 	}
 	fn upper() -> Permill {
-		Permill::from_parts(250_000)
+		Permill::zero()
 	}
 }
 


### PR DESCRIPTION
This makes EVM base fee a bit low, and also fixes the issue with #226 

The base fee is 0.1 GWei by default, and with no elasticity, which means we have a constant base fees, that's OKAY for now. A better option is to use a more dynamic base fee depends on the network conditions ..etc 

Reference: https://github.com/moonbeam-foundation/moonbeam/blob/61647d84124c8e6d099176ce5ba357f821204864/runtime/moonbeam/src/lib.rs#L403-L426