### PR TITLE
CLI to sign data using authority wdkg key

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace.package]
-version = "0.4.5"
+version = "0.4.8"
 authors = ["Webb Technologies Inc."]
 edition = "2021"
 license = "Unlicense"

--- a/standalone/node/src/cli.rs
+++ b/standalone/node/src/cli.rs
@@ -92,4 +92,7 @@ pub enum Subcommand {
 
 	/// Db meta columns information.
 	FrontierDb(fc_cli::FrontierDbCmd),
+
+	/// DKG signer
+	DKGSigner(crate::signer_cli::DKGSignerCmd),
 }

--- a/standalone/node/src/command.rs
+++ b/standalone/node/src/command.rs
@@ -75,6 +75,7 @@ pub fn run() -> sc_cli::Result<()> {
 
 	match &cli.subcommand {
 		Some(Subcommand::Key(cmd)) => cmd.run(&cli),
+		Some(Subcommand::DKGSigner(cmd)) => cmd.run(&cli),
 		Some(Subcommand::DKGKey(cmd)) => cmd.run(&cli),
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;

--- a/standalone/node/src/lib.rs
+++ b/standalone/node/src/lib.rs
@@ -4,5 +4,6 @@ pub mod distributions;
 pub mod eth;
 pub mod rpc;
 pub mod service;
+pub mod signer_cli;
 pub mod testnet_fixtures;
 pub mod utils;

--- a/standalone/node/src/main.rs
+++ b/standalone/node/src/main.rs
@@ -10,6 +10,7 @@ mod command;
 mod distributions;
 mod eth;
 mod rpc;
+mod signer_cli;
 mod testnet_fixtures;
 mod utils;
 

--- a/standalone/node/src/signer_cli.rs
+++ b/standalone/node/src/signer_cli.rs
@@ -19,17 +19,11 @@ use sc_cli::{
 	utils, with_crypto_scheme, CryptoScheme, Error, KeystoreParams, Result as CliResult,
 	SharedParams, SubstrateCli,
 };
-use sc_client_api::{backend::Backend as BackendT, blockchain::HeaderBackend};
 use sc_keystore::LocalKeystore;
-use sc_network::config::Secret;
 use sc_service::{config::KeystoreConfig, BasePath};
-use sp_blockchain::Info;
 use sp_keystore::KeystorePtr;
 use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
-use std::{fmt::Debug, io};
-
-use serde_json::to_vec;
-use sp_core::crypto::KeyTypeId;
+use std::fmt::Debug;
 
 /// The `chain-info` subcommand used to output db meta columns information.
 #[derive(Debug, Clone, clap::Parser)]
@@ -71,9 +65,11 @@ impl DKGSignerCmd {
 		let maybe_public = keystore.ecdsa_public_keys(key_type);
 		let public = maybe_public.first().unwrap();
 
-		keystore
+		let signature = keystore
 			.ecdsa_sign(key_type, &public, &self.data.as_bytes())
 			.map_err(|_| Error::KeystoreOperation)?;
+
+		println!("Signature : {:?}", signature);
 
 		Ok(())
 	}

--- a/standalone/node/src/signer_cli.rs
+++ b/standalone/node/src/signer_cli.rs
@@ -1,0 +1,80 @@
+#![allow(clippy::all)]
+// Copyright 2023 Webb Technologies Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Signer module to sign data with wdkg keytype in keystore
+use parity_scale_codec::{Decode, Encode};
+use sc_cli::{
+	utils, with_crypto_scheme, CryptoScheme, Error, KeystoreParams, Result as CliResult,
+	SharedParams, SubstrateCli,
+};
+use sc_client_api::{backend::Backend as BackendT, blockchain::HeaderBackend};
+use sc_keystore::LocalKeystore;
+use sc_network::config::Secret;
+use sc_service::{config::KeystoreConfig, BasePath};
+use sp_blockchain::Info;
+use sp_keystore::KeystorePtr;
+use sp_runtime::traits::{Block as BlockT, Header as HeaderT};
+use std::{fmt::Debug, io};
+
+use serde_json::to_vec;
+use sp_core::crypto::KeyTypeId;
+
+/// The `chain-info` subcommand used to output db meta columns information.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct DKGSignerCmd {
+	/// Key type, examples: "gran", or "imon".
+	#[arg(long)]
+	data: String,
+
+	#[allow(missing_docs)]
+	#[clap(flatten)]
+	pub shared_params: SharedParams,
+
+	#[allow(missing_docs)]
+	#[clap(flatten)]
+	pub keystore_params: KeystoreParams,
+}
+
+impl DKGSignerCmd {
+	/// Run the command
+	pub fn run<C: SubstrateCli>(&self, cli: &C) -> Result<(), Error> {
+		let base_path = self
+			.shared_params
+			.base_path()?
+			.unwrap_or_else(|| BasePath::from_project("", "", &C::executable_name()));
+		let chain_id = self.shared_params.chain_id(self.shared_params.is_dev());
+		let chain_spec = cli.load_spec(&chain_id)?;
+		let config_dir = base_path.config_dir(chain_spec.id());
+
+		let keystore = match self.keystore_params.keystore_config(&config_dir)? {
+			KeystoreConfig::Path { path, password } => {
+				let keystore: KeystorePtr = LocalKeystore::open(path, password)?.into();
+				keystore
+			},
+			_ => unreachable!("keystore_config always returns path and password; qed"),
+		};
+
+		let key_type = dkg_runtime_primitives::KEY_TYPE;
+
+		let maybe_public = keystore.ecdsa_public_keys(key_type);
+		let public = maybe_public.first().unwrap();
+
+		keystore
+			.ecdsa_sign(key_type, &public, &self.data.as_bytes())
+			.map_err(|_| Error::KeystoreOperation)?;
+
+		Ok(())
+	}
+}


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- CLI to sign data using authority wdkg key 

Output :
```
./target/debug/tangle-standalone dkg-signer --data test
Signature : Some(4cced2b27ac145e0512abad5756fe45c173c130c18c80bdf0017ba0416edc690261bf1780b00dd30209dff8e13ce8df22d0402311d610cdd921bdff3a6a51b0101)
```

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes https://github.com/webb-tools/dkg-substrate/issues/717
