### PR TITLE
Validator re-staking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9059,10 +9059,14 @@ name = "pallet-roles"
 version = "0.5.0"
 dependencies = [
  "frame-benchmarking",
+ "frame-election-provider-support",
  "frame-support",
  "frame-system",
  "hex-literal 0.3.4",
  "pallet-balances",
+ "pallet-session",
+ "pallet-staking",
+ "pallet-timestamp",
  "parity-scale-codec",
  "scale-info",
  "serde",
@@ -9070,6 +9074,7 @@ dependencies = [
  "sp-core 21.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0)",
  "sp-io 23.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0)",
  "sp-runtime 24.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0)",
+ "sp-staking",
  "sp-std 8.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0)",
  "tangle-primitives",
 ]
@@ -9125,6 +9130,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
+ "rand_chacha 0.2.2",
  "scale-info",
  "serde",
  "sp-application-crypto 23.0.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v1.0.0)",

--- a/pallets/roles/Cargo.toml
+++ b/pallets/roles/Cargo.toml
@@ -17,11 +17,16 @@ serde = { workspace = true }
 frame-support = { workspace = true }
 frame-system = { workspace = true }
 pallet-balances = { workspace = true }
+pallet-staking = { workspace = true }
+pallet-session = { workspace = true }
+pallet-timestamp = { workspace = true }
 sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
+sp-staking = { workspace = true }
 tangle-primitives = {workspace = true, default-features = false }
 frame-benchmarking = { workspace = true, optional = true }
+frame-election-provider-support = { workspace = true }
 
 [dev-dependencies]
 hex-literal = { workspace = true }
@@ -40,8 +45,13 @@ std = [
   "sp-runtime/std",
   "sp-std/std",
   "sp-io/std",
+  "sp-staking/std",
   "pallet-balances/std",
-  "tangle-primitives/std"
+  "pallet-staking/std",
+  "pallet-session/std",
+  "pallet-timestamp/std",
+  "tangle-primitives/std",
+  "frame-election-provider-support/std",
 ]
 
 try-runtime = ["frame-support/try-runtime"]
@@ -50,5 +60,9 @@ runtime-benchmarks = [
   "frame-support/runtime-benchmarks",
   "frame-system/runtime-benchmarks",
   "sp-runtime/runtime-benchmarks",
-  "pallet-balances/runtime-benchmarks"
+  "sp-staking/runtime-benchmarks",
+  "pallet-balances/runtime-benchmarks",
+  "pallet-staking/runtime-benchmarks",
+  "pallet-timestamp/runtime-benchmarks",
+  "frame-election-provider-support/runtime-benchmarks",
 ]

--- a/pallets/roles/src/lib.rs
+++ b/pallets/roles/src/lib.rs
@@ -267,8 +267,7 @@ pub mod pallet {
 			ensure!(!AccountRolesMapping::<T>::contains_key(&account), Error::<T>::HasRoleAssigned);
 
 			// chill
-			let _ = pallet_staking::Pallet::<T>::chill(origin);
-			Ok(())
+			pallet_staking::Pallet::<T>::chill(origin)
 		}
 
 		/// Unbound funds from the stash account.
@@ -296,9 +295,11 @@ pub mod pallet {
 			ensure!(!AccountRolesMapping::<T>::contains_key(&account), Error::<T>::HasRoleAssigned);
 
 			// Unbound funds.
-			let _ = pallet_staking::Pallet::<T>::unbond(origin, amount);
-
-			Ok(())
+			let res = pallet_staking::Pallet::<T>::unbond(origin, amount);
+			match res {
+				Ok(_) => Ok(()),
+				Err(dispatch_post_info) => Err(dispatch_post_info.error),
+			}
 		}
 
 		/// Withdraw unbound funds after un-bonding period has passed.
@@ -320,9 +321,11 @@ pub mod pallet {
 			);
 
 			// Withdraw unbound funds.
-			let _ = pallet_staking::Pallet::<T>::withdraw_unbonded(origin, 0);
-
-			Ok(())
+			let res = pallet_staking::Pallet::<T>::withdraw_unbonded(origin, 0);
+			match res {
+				Ok(_) => Ok(()),
+				Err(dispatch_post_info) => Err(dispatch_post_info.error),
+			}
 		}
 	}
 }

--- a/pallets/roles/src/lib.rs
+++ b/pallets/roles/src/lib.rs
@@ -108,10 +108,6 @@ pub mod pallet {
 		RoleAssigned { account: T::AccountId, role: RoleType },
 		/// Removed validator from role.
 		RoleRemoved { account: T::AccountId, role: RoleType },
-		/// Funds bonded to become a validator.
-		Bonded { account: T::AccountId, amount: BalanceOf<T> },
-		/// Funds unbonded to stop being a validator.
-		Unbonded { account: T::AccountId, amount: BalanceOf<T> },
 		/// Slashed validator.
 		Slashed { account: T::AccountId, amount: BalanceOf<T> },
 	}

--- a/pallets/roles/src/lib.rs
+++ b/pallets/roles/src/lib.rs
@@ -187,7 +187,8 @@ pub mod pallet {
 			// Check if stash account is already paired/ re-staked.
 			ensure!(!<Ledger<T>>::contains_key(&stash_account), Error::<T>::AccountAlreadyPaired);
 
-			let staking_ledger = pallet_staking::Ledger::<T>::get(&stash_account).unwrap();
+			let staking_ledger =
+				pallet_staking::Ledger::<T>::get(&stash_account).ok_or(Error::<T>::NotValidator)?;
 			let re_stake_amount = match re_stake {
 				ReStakingOption::Full => staking_ledger.active,
 				ReStakingOption::Custom(x) => x.into(),

--- a/pallets/roles/src/mock.rs
+++ b/pallets/roles/src/mock.rs
@@ -97,6 +97,19 @@ impl Contains<RuntimeCall> for BaseFilter {
 			return false
 		}
 
+		// no chill call
+		if matches!(call, RuntimeCall::Staking(pallet_staking::Call::chill { .. })) {
+			return false
+		}
+
+		// no withdraw_unbonded call
+		let is_stake_withdraw_call =
+			matches!(call, RuntimeCall::Staking(pallet_staking::Call::withdraw_unbonded { .. }));
+
+		if is_stake_withdraw_call {
+			return false
+		}
+
 		true
 	}
 }

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -17,7 +17,6 @@
 use super::*;
 use frame_support::{assert_err, assert_ok};
 use mock::*;
-use tangle_primitives::jobs::ValidatorOffence;
 
 #[test]
 fn test_assign_role() {
@@ -56,27 +55,6 @@ fn test_clear_role() {
 
 		// Ledger should be removed from ledger mappings.
 		assert_eq!(Roles::ledger(1), None);
-	});
-}
-
-#[test]
-fn test_slash_validator() {
-	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
-		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
-		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
-		// have 5000 tokens usable.
-		assert_eq!(Balances::usable_balance(1), 5000);
-
-		// Now lets slash the account for being Inactive.
-		assert_ok!(Roles::slash_validator(1, ValidatorOffence::Inactivity));
-
-		assert_events(vec![RuntimeEvent::Roles(crate::Event::Slashed {
-			account: 1,
-			amount: 1000,
-		})]);
-		// should be updated in ledger
-		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 4000 }));
 	});
 }
 

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -22,7 +22,11 @@ use mock::*;
 fn test_assign_role() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::Tss,
+			ReStakingOption::Custom(5000)
+		));
 
 		assert_events(vec![RuntimeEvent::Roles(crate::Event::RoleAssigned {
 			account: 1,
@@ -36,11 +40,38 @@ fn test_assign_role() {
 	});
 }
 
+// Test that we can assign role with full staking option.
+#[test]
+fn test_assign_role_with_full_staking_option() {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
+		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::Tss,
+			ReStakingOption::Full
+		));
+
+		assert_events(vec![RuntimeEvent::Roles(crate::Event::RoleAssigned {
+			account: 1,
+			role: RoleType::Tss,
+		})]);
+
+		// Lets verify role assigned to account.
+		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
+		// Verify ledger mapping
+		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 10000 }));
+	});
+}
+
 #[test]
 fn test_clear_role() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::Tss,
+			ReStakingOption::Custom(5000)
+		));
 
 		// Now lets clear the role
 		assert_ok!(Roles::clear_role(RuntimeOrigin::signed(1), RoleType::Tss));
@@ -63,7 +94,11 @@ fn test_assign_role_should_fail_if_not_validator() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// we will use account 5 which is not a validator
 		assert_err!(
-			Roles::assign_role(RuntimeOrigin::signed(5), RoleType::Tss, 5000),
+			Roles::assign_role(
+				RuntimeOrigin::signed(5),
+				RoleType::Tss,
+				ReStakingOption::Custom(5000)
+			),
 			Error::<Runtime>::NotValidator
 		);
 	});
@@ -74,7 +109,11 @@ fn test_unbound_funds_should_work() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially validator account has staked 10_000 tokens and wants to re-stake 5000 tokens
 		// for providing TSS services.
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::Tss,
+			ReStakingOption::Custom(5000)
+		));
 
 		// Lets verify role is assigned to account.
 		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
@@ -106,7 +145,11 @@ fn test_unbound_funds_should_fail_if_role_assigned() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially validator account has staked 10_000 tokens and wants to re-stake 5000 tokens
 		// for providing TSS services.
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::Tss,
+			ReStakingOption::Custom(5000)
+		));
 
 		// Lets verify role is assigned to account.
 		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -23,7 +23,7 @@ use tangle_primitives::jobs::ValidatorOffence;
 fn test_assign_role() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), 5000, RoleType::Tss));
+		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
 
 		assert_events(vec![
 			RuntimeEvent::Roles(crate::Event::Bonded { account: 1, amount: 5000 }),
@@ -33,7 +33,7 @@ fn test_assign_role() {
 		// Lets verify role assigned to account.
 		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
 		// Verify ledger mapping
-		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total_locked: 5000 }));
+		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 5000 }));
 		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
 		// have 5000 tokens usable.
 		assert_eq!(Balances::usable_balance(1), 5000);
@@ -44,7 +44,7 @@ fn test_assign_role() {
 fn test_clear_role() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), 5000, RoleType::Tss));
+		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
 		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
 		// have 5000 tokens usable.
 		assert_eq!(Balances::usable_balance(1), 5000);
@@ -73,7 +73,7 @@ fn test_clear_role() {
 fn test_slash_validator() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), 5000, RoleType::Tss));
+		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), RoleType::Tss, 5000));
 		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
 		// have 5000 tokens usable.
 		assert_eq!(Balances::usable_balance(1), 5000);
@@ -86,7 +86,7 @@ fn test_slash_validator() {
 			amount: 1000,
 		})]);
 		// should be updated in ledger
-		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total_locked: 4000 }));
+		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 4000 }));
 	});
 }
 
@@ -95,7 +95,7 @@ fn test_assign_role_should_fail_if_not_validator() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// we will use account 5 which is not a validator
 		assert_err!(
-			Roles::assign_role(RuntimeOrigin::signed(5), 5000, RoleType::Tss),
+			Roles::assign_role(RuntimeOrigin::signed(5), RoleType::Tss, 5000),
 			Error::<Runtime>::NotValidator
 		);
 	});

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -15,78 +15,88 @@
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 #![cfg(test)]
 use super::*;
-use frame_support::assert_ok;
+use frame_support::{assert_err, assert_ok};
 use mock::*;
 use tangle_primitives::jobs::ValidatorOffence;
 
 #[test]
 fn test_assign_role() {
-	new_test_ext().execute_with(|| {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(10), 5000, RoleType::Tss));
+		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), 5000, RoleType::Tss));
 
 		assert_events(vec![
-			RuntimeEvent::Roles(crate::Event::Bonded { account: 10, amount: 5000 }),
-			RuntimeEvent::Roles(crate::Event::RoleAssigned { account: 10, role: RoleType::Tss }),
+			RuntimeEvent::Roles(crate::Event::Bonded { account: 1, amount: 5000 }),
+			RuntimeEvent::Roles(crate::Event::RoleAssigned { account: 1, role: RoleType::Tss }),
 		]);
 
 		// Lets verify role assigned to account.
-		assert_eq!(Roles::account_role(10), Some(RoleType::Tss));
+		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
 		// Verify ledger mapping
-		assert_eq!(Roles::ledger(10), Some(RoleStakingLedger { stash: 10, total_locked: 5000 }));
+		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total_locked: 5000 }));
 		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
 		// have 5000 tokens usable.
-		assert_eq!(Balances::usable_balance(10), 5000);
+		assert_eq!(Balances::usable_balance(1), 5000);
 	});
 }
 
 #[test]
 fn test_clear_role() {
-	new_test_ext().execute_with(|| {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(10), 5000, RoleType::Tss));
+		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), 5000, RoleType::Tss));
 		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
 		// have 5000 tokens usable.
-		assert_eq!(Balances::usable_balance(10), 5000);
+		assert_eq!(Balances::usable_balance(1), 5000);
 
 		// Now lets clear the role
-		assert_ok!(Roles::clear_role(RuntimeOrigin::signed(10), RoleType::Tss));
+		assert_ok!(Roles::clear_role(RuntimeOrigin::signed(1), RoleType::Tss));
 
 		assert_events(vec![
-			RuntimeEvent::Roles(crate::Event::Unbonded { account: 10, amount: 5000 }),
-			RuntimeEvent::Roles(crate::Event::RoleRemoved { account: 10, role: RoleType::Tss }),
+			RuntimeEvent::Roles(crate::Event::Unbonded { account: 1, amount: 5000 }),
+			RuntimeEvent::Roles(crate::Event::RoleRemoved { account: 1, role: RoleType::Tss }),
 		]);
 
 		// Role should be removed from  account role mappings.
-		assert_eq!(Roles::account_role(10), None);
+		assert_eq!(Roles::account_role(1), None);
 
 		// Ledger should be removed from ledger mappings.
-		assert_eq!(Roles::ledger(10), None);
+		assert_eq!(Roles::ledger(1), None);
 
 		// Verify total usable balance of the account. Since we have cleared the role, we should
 		// have 10000 tokens usable.
-		assert_eq!(Balances::usable_balance(10), 10000);
+		assert_eq!(Balances::usable_balance(1), 10000);
 	});
 }
 
-// test slashing
 #[test]
 fn test_slash_validator() {
-	new_test_ext().execute_with(|| {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(10), 5000, RoleType::Tss));
+		assert_ok!(Roles::assign_role(RuntimeOrigin::signed(1), 5000, RoleType::Tss));
 		// Verify total usable balance of the account. Since we have bonded 5000 tokens, we should
 		// have 5000 tokens usable.
-		assert_eq!(Balances::usable_balance(10), 5000);
+		assert_eq!(Balances::usable_balance(1), 5000);
 
 		// Now lets slash the account for being Inactive.
-		assert_ok!(Roles::slash_validator(10, ValidatorOffence::Inactivity));
+		assert_ok!(Roles::slash_validator(1, ValidatorOffence::Inactivity));
 
 		assert_events(vec![RuntimeEvent::Roles(crate::Event::Slashed {
-			account: 10,
+			account: 1,
 			amount: 1000,
 		})]);
 		// should be updated in ledger
-		assert_eq!(Roles::ledger(10), Some(RoleStakingLedger { stash: 10, total_locked: 4000 }));
+		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total_locked: 4000 }));
+	});
+}
+
+#[test]
+fn test_assign_role_should_fail_if_not_validator() {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
+		// we will use account 5 which is not a validator
+		assert_err!(
+			Roles::assign_role(RuntimeOrigin::signed(5), 5000, RoleType::Tss),
+			Error::<Runtime>::NotValidator
+		);
 	});
 }

--- a/primitives/src/types/roles.rs
+++ b/primitives/src/types/roles.rs
@@ -46,3 +46,13 @@ impl From<JobKey> for RoleType {
 		}
 	}
 }
+
+
+ /// Role type to be used in the system.
+ #[derive(Encode, Decode, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
+ pub enum ReStakingOption {
+	// Re-stake all the staked funds for selected role.
+	Full,
+	// Re-stake only the given amount of funds for selected role.
+	Custom(u64)
+ }

--- a/primitives/src/types/roles.rs
+++ b/primitives/src/types/roles.rs
@@ -47,12 +47,11 @@ impl From<JobKey> for RoleType {
 	}
 }
 
-
- /// Role type to be used in the system.
- #[derive(Encode, Decode, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
- pub enum ReStakingOption {
+/// Role type to be used in the system.
+#[derive(Encode, Decode, Clone, Copy, Debug, PartialEq, Eq, TypeInfo)]
+pub enum ReStakingOption {
 	// Re-stake all the staked funds for selected role.
 	Full,
 	// Re-stake only the given amount of funds for selected role.
-	Custom(u64)
- }
+	Custom(u64),
+}

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1097,12 +1097,28 @@ impl Contains<RuntimeCall> for BaseFilter {
 			// no paused call
 			return false
 		}
-
+		// Following staking pallet calls will be blocked and will be allowed to execute
+		// through role pallet.
 		let is_stake_unbound_call =
 			matches!(call, RuntimeCall::Staking(pallet_staking::Call::unbond { .. }));
 
 		if is_stake_unbound_call {
 			// no unbond call
+			return false
+		}
+
+		// no chill call
+		if matches!(call, RuntimeCall::Staking(pallet_staking::Call::chill { .. })) {
+			return false
+		}
+
+		// no withdraw_unbonded call
+		let is_stake_withdraw_call =  matches!(
+			call,
+			RuntimeCall::Staking(pallet_staking::Call::withdraw_unbonded { .. })
+		);
+
+		if is_stake_withdraw_call{
 			return false
 		}
 

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1099,7 +1099,7 @@ impl Contains<RuntimeCall> for BaseFilter {
 		}
 
 		let is_stake_unbound_call =
-			matches!(call, RuntimeCall::Staking(pallet_staking::Call::unbond{..}));
+			matches!(call, RuntimeCall::Staking(pallet_staking::Call::unbond { .. }));
 
 		if is_stake_unbound_call {
 			// no unbond call

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1098,6 +1098,14 @@ impl Contains<RuntimeCall> for BaseFilter {
 			return false
 		}
 
+		let is_stake_unbound_call =
+			matches!(call, RuntimeCall::Staking(pallet_staking::Call::unbond{..}));
+
+		if is_stake_unbound_call {
+			// no unbond call
+			return false
+		}
+
 		let democracy_related = matches!(
 			call,
 			// Filter democracy proposals creation

--- a/standalone/runtime/src/lib.rs
+++ b/standalone/runtime/src/lib.rs
@@ -1113,12 +1113,10 @@ impl Contains<RuntimeCall> for BaseFilter {
 		}
 
 		// no withdraw_unbonded call
-		let is_stake_withdraw_call =  matches!(
-			call,
-			RuntimeCall::Staking(pallet_staking::Call::withdraw_unbonded { .. })
-		);
+		let is_stake_withdraw_call =
+			matches!(call, RuntimeCall::Staking(pallet_staking::Call::withdraw_unbonded { .. }));
 
-		if is_stake_withdraw_call{
+		if is_stake_withdraw_call {
 			return false
 		}
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- [x] Simple Re-staking implementation
    - The account should be a validator account
    - User chooses to re-stake Full or Custom amount.
    - Re-stake value should meet the minimum value requirement to opt for the role.
    - The user can chill, unbound, and withdraw_unbound only when he has opted out of all the services and the role is cleared.
   
- [x] Update and add new tests.

## Note
- `chill` , `unbound` , `withdraw_unbound` calls from staking-pallet are blocked and are only allowed through roles pallet
- The slashing part will be covered in separate PR.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #291 
