### PR TITLE
Support multiple roles

### DIFF
--- a/pallets/roles/src/impls.rs
+++ b/pallets/roles/src/impls.rs
@@ -15,7 +15,7 @@
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use sp_runtime::{DispatchResult, Saturating};
+use sp_runtime::{DispatchResult, Percent, Saturating};
 use tangle_primitives::{roles::RoleType, traits::roles::RolesHandler};
 
 /// Implements RolesHandler for the pallet.
@@ -118,6 +118,18 @@ impl<T: Config> Pallet<T> {
 			return true
 		}
 		false
+	}
+
+	/// Calculate max re-stake amount for the given account.
+	///
+	/// # Parameters
+	/// - `total_stake`: Total stake of the validator
+	///
+	/// # Returns
+	/// Returns the max re-stake amount.
+	pub fn calculate_max_re_stake_amount(total_stake: BalanceOf<T>) -> BalanceOf<T> {
+		// User can re-stake max 50% of the total stake
+		Percent::from_percent(50) * total_stake
 	}
 
 	/// Get the total amount of the balance that is locked for the given stash.

--- a/pallets/roles/src/impls.rs
+++ b/pallets/roles/src/impls.rs
@@ -15,7 +15,7 @@
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 
 use super::*;
-use sp_runtime::Saturating;
+use sp_runtime::{DispatchResult, Saturating};
 use tangle_primitives::{roles::RoleType, traits::roles::RolesHandler};
 
 /// Implements RolesHandler for the pallet.
@@ -29,16 +29,7 @@ impl<T: Config> RolesHandler<T::AccountId> for Pallet<T> {
 	/// # Returns
 	/// Returns `true` if the validator is permitted to work with this job type, otherwise `false`.
 	fn is_validator(address: T::AccountId, role: RoleType) -> bool {
-		let assigned_role = AccountRolesMapping::<T>::get(address);
-		match assigned_role {
-			Some(r) =>
-				if r == role {
-					return true
-				},
-			None => return false,
-		}
-
-		false
+		Self::has_role(address, role)
 	}
 
 	/// Slash validator stake for the reported offence. The function should be a best effort
@@ -63,6 +54,72 @@ impl<T: Config> RolesHandler<T::AccountId> for Pallet<T> {
 
 /// Functions for the pallet.
 impl<T: Config> Pallet<T> {
+	/// Add new role to the given account.
+	///
+	/// # Parameters
+	/// - `account`: The account ID of the validator.
+	/// - `role`: Selected role type.
+	pub fn add_role(account: T::AccountId, role: RoleType) -> DispatchResult {
+		AccountRolesMapping::<T>::try_mutate(&account, |roles| {
+			if !roles.contains(&role) {
+				roles.try_push(role.clone()).map_err(|_| Error::<T>::MaxRoles)?;
+
+				Ok(())
+			} else {
+				Err(Error::<T>::HasRoleAssigned.into())
+			}
+		})
+	}
+
+	/// Remove role from the given account.
+	///
+	/// # Parameters
+	/// - `account`: The account ID of the validator.
+	/// - `role`: Selected role type.
+	pub fn remove_role(account: T::AccountId, role: RoleType) -> DispatchResult {
+		AccountRolesMapping::<T>::try_mutate(&account, |roles| {
+			if roles.contains(&role) {
+				roles.retain(|r| r != &role);
+
+				Ok(())
+			} else {
+				Err(Error::<T>::NoRoleAssigned.into())
+			}
+		})
+	}
+
+	/// Check if the given account has the given role.
+	///
+	/// # Parameters
+	/// - `account`: The account ID of the validator.
+	/// - `role`: Selected role type.
+	///
+	/// # Returns
+	/// Returns `true` if the validator is permitted to work with this job type, otherwise `false`.
+	pub fn has_role(account: T::AccountId, role: RoleType) -> bool {
+		let assigned_roles = AccountRolesMapping::<T>::get(account);
+		match assigned_roles.iter().find(|r| **r == role) {
+			Some(_) => true,
+			None => false,
+		}
+	}
+
+	/// Check if account can chill, unbound and withdraw funds.
+	///
+	/// # Parameters
+	/// - `account`: The account ID of the validator.
+	///
+	/// # Returns
+	/// Returns boolean value.
+	pub fn can_exit(account: T::AccountId) -> bool {
+		let assigned_roles = AccountRolesMapping::<T>::get(account);
+		if assigned_roles.is_empty() {
+			// Role is cleared, account can chill, unbound and withdraw funds.
+			return true
+		}
+		false
+	}
+
 	/// Get the total amount of the balance that is locked for the given stash.
 	///
 	/// # Parameters

--- a/pallets/roles/src/mock.rs
+++ b/pallets/roles/src/mock.rs
@@ -200,13 +200,9 @@ impl pallet_staking::Config for Runtime {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	pub const RolesPalletId: PalletId = PalletId(*b"py/roles");
-}
-
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
-	type PalletId = RolesPalletId;
+	type MaxRolesPerAccount = ConstU32<2>;
 	type WeightInfo = ();
 }
 

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -36,7 +36,14 @@ fn test_assign_role() {
 		// Lets verify role assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
 		// Verify ledger mapping
-		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 5000 }));
+		assert_eq!(
+			Roles::ledger(1),
+			Some(RoleStakingLedger {
+				stash: 1,
+				total: 5000,
+				roles: vec![RoleStakeInfo { role: RoleType::Tss, re_staked: 5000 }]
+			})
+		);
 	});
 }
 
@@ -59,7 +66,14 @@ fn test_assign_role_with_full_staking_option() {
 		// Lets verify role assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
 		// Verify ledger mapping
-		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 10000 }));
+		assert_eq!(
+			Roles::ledger(1),
+			Some(RoleStakingLedger {
+				stash: 1,
+				total: 10000,
+				roles: vec![RoleStakeInfo { role: RoleType::Tss, re_staked: 10000 }]
+			})
+		);
 	});
 }
 
@@ -86,6 +100,18 @@ fn test_assign_multiple_roles() {
 
 		// Lets verify role assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::ZkSaas), true);
+
+		assert_eq!(
+			Roles::ledger(1),
+			Some(RoleStakingLedger {
+				stash: 1,
+				total: 20000,
+				roles: vec![
+					RoleStakeInfo { role: RoleType::Tss, re_staked: 10000 },
+					RoleStakeInfo { role: RoleType::ZkSaas, re_staked: 10000 },
+				]
+			})
+		);
 	});
 }
 

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -19,14 +19,14 @@ use frame_support::{assert_err, assert_ok};
 use mock::*;
 
 #[test]
-fn test_assign_role() {
+fn test_assign_roles() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::Tss,
-			ReStakingOption::Custom(5000)
-		));
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 }];
+
+		assert_ok!(Roles::assign_roles(RuntimeOrigin::signed(1), role_records));
 
 		assert_events(vec![RuntimeEvent::Roles(crate::Event::RoleAssigned {
 			account: 1,
@@ -41,37 +41,7 @@ fn test_assign_role() {
 			Some(RoleStakingLedger {
 				stash: 1,
 				total: 5000,
-				roles: vec![RoleStakeInfo { role: RoleType::Tss, re_staked: 5000 }]
-			})
-		);
-	});
-}
-
-// Test that we can assign role with full staking option.
-#[test]
-fn test_assign_role_with_full_staking_option() {
-	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
-		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::Tss,
-			ReStakingOption::Full
-		));
-
-		assert_events(vec![RuntimeEvent::Roles(crate::Event::RoleAssigned {
-			account: 1,
-			role: RoleType::Tss,
-		})]);
-
-		// Lets verify role assigned to account.
-		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
-		// Verify ledger mapping
-		assert_eq!(
-			Roles::ledger(1),
-			Some(RoleStakingLedger {
-				stash: 1,
-				total: 10000,
-				roles: vec![RoleStakeInfo { role: RoleType::Tss, re_staked: 10000 }]
+				roles: vec![RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 }]
 			})
 		);
 	});
@@ -82,21 +52,17 @@ fn test_assign_role_with_full_staking_option() {
 fn test_assign_multiple_roles() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::Tss,
-			ReStakingOption::Full
-		));
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![
+			RoleStakingRecord { role: RoleType::Tss, re_staked: 2500 },
+			RoleStakingRecord { role: RoleType::ZkSaas, re_staked: 2500 },
+		];
+
+		assert_ok!(Roles::assign_roles(RuntimeOrigin::signed(1), role_records));
 
 		// Lets verify role assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
-
-		// Now lets assign another role to the same account.
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::ZkSaas,
-			ReStakingOption::Full
-		));
 
 		// Lets verify role assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::ZkSaas), true);
@@ -105,12 +71,32 @@ fn test_assign_multiple_roles() {
 			Roles::ledger(1),
 			Some(RoleStakingLedger {
 				stash: 1,
-				total: 20000,
+				total: 5000,
 				roles: vec![
-					RoleStakeInfo { role: RoleType::Tss, re_staked: 10000 },
-					RoleStakeInfo { role: RoleType::ZkSaas, re_staked: 10000 },
+					RoleStakingRecord { role: RoleType::Tss, re_staked: 2500 },
+					RoleStakingRecord { role: RoleType::ZkSaas, re_staked: 2500 },
 				]
 			})
+		);
+	});
+}
+
+// Test assign roles, should fail if total re-stake value exceeds max re-stake value.
+// Max re-stake value is 5000 (50% of total staked value).
+#[test]
+fn test_assign_roles_should_fail_if_total_re_stake_value_exceeds_max_re_stake_value() {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
+		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![
+			RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 },
+			RoleStakingRecord { role: RoleType::ZkSaas, re_staked: 5000 },
+		];
+		// Since max re_stake limit is 5000 it should fail with `ExceedsMaxReStakeValue` error.
+		assert_err!(
+			Roles::assign_roles(RuntimeOrigin::signed(1), role_records),
+			Error::<Runtime>::ExceedsMaxReStakeValue
 		);
 	});
 }
@@ -119,11 +105,11 @@ fn test_assign_multiple_roles() {
 fn test_clear_role() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::Tss,
-			ReStakingOption::Custom(5000)
-		));
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 }];
+
+		assert_ok!(Roles::assign_roles(RuntimeOrigin::signed(1), role_records));
 
 		// Now lets clear the role
 		assert_ok!(Roles::clear_role(RuntimeOrigin::signed(1), RoleType::Tss));
@@ -142,15 +128,15 @@ fn test_clear_role() {
 }
 
 #[test]
-fn test_assign_role_should_fail_if_not_validator() {
+fn test_assign_roles_should_fail_if_not_validator() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// we will use account 5 which is not a validator
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 }];
+
 		assert_err!(
-			Roles::assign_role(
-				RuntimeOrigin::signed(5),
-				RoleType::Tss,
-				ReStakingOption::Custom(5000)
-			),
+			Roles::assign_roles(RuntimeOrigin::signed(5), role_records),
 			Error::<Runtime>::NotValidator
 		);
 	});
@@ -161,11 +147,11 @@ fn test_unbound_funds_should_work() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially validator account has staked 10_000 tokens and wants to re-stake 5000 tokens
 		// for providing TSS services.
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::Tss,
-			ReStakingOption::Custom(5000)
-		));
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 }];
+
+		assert_ok!(Roles::assign_roles(RuntimeOrigin::signed(1), role_records));
 
 		// Lets verify role is assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
@@ -197,11 +183,11 @@ fn test_unbound_funds_should_fail_if_role_assigned() {
 	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
 		// Initially validator account has staked 10_000 tokens and wants to re-stake 5000 tokens
 		// for providing TSS services.
-		assert_ok!(Roles::assign_role(
-			RuntimeOrigin::signed(1),
-			RoleType::Tss,
-			ReStakingOption::Custom(5000)
-		));
+
+		// Roles user is interested in re-staking.
+		let role_records = vec![RoleStakingRecord { role: RoleType::Tss, re_staked: 5000 }];
+
+		assert_ok!(Roles::assign_roles(RuntimeOrigin::signed(1), role_records));
 
 		// Lets verify role is assigned to account.
 		assert_eq!(Roles::has_role(1, RoleType::Tss), true);

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -34,7 +34,7 @@ fn test_assign_role() {
 		})]);
 
 		// Lets verify role assigned to account.
-		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
+		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
 		// Verify ledger mapping
 		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 5000 }));
 	});
@@ -57,9 +57,35 @@ fn test_assign_role_with_full_staking_option() {
 		})]);
 
 		// Lets verify role assigned to account.
-		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
+		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
 		// Verify ledger mapping
 		assert_eq!(Roles::ledger(1), Some(RoleStakingLedger { stash: 1, total: 10000 }));
+	});
+}
+
+// test assign multiple roles to an account.
+#[test]
+fn test_assign_multiple_roles() {
+	new_test_ext_raw_authorities(vec![1, 2, 3, 4]).execute_with(|| {
+		// Initially account if funded with 10000 tokens and we are trying to bond 5000 tokens
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::Tss,
+			ReStakingOption::Full
+		));
+
+		// Lets verify role assigned to account.
+		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
+
+		// Now lets assign another role to the same account.
+		assert_ok!(Roles::assign_role(
+			RuntimeOrigin::signed(1),
+			RoleType::ZkSaas,
+			ReStakingOption::Full
+		));
+
+		// Lets verify role assigned to account.
+		assert_eq!(Roles::has_role(1, RoleType::ZkSaas), true);
 	});
 }
 
@@ -82,7 +108,7 @@ fn test_clear_role() {
 		})]);
 
 		// Role should be removed from  account role mappings.
-		assert_eq!(Roles::account_role(1), None);
+		assert_eq!(Roles::has_role(1, RoleType::Tss), false);
 
 		// Ledger should be removed from ledger mappings.
 		assert_eq!(Roles::ledger(1), None);
@@ -116,13 +142,13 @@ fn test_unbound_funds_should_work() {
 		));
 
 		// Lets verify role is assigned to account.
-		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
+		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
 
 		// Lets clear the role.
 		assert_ok!(Roles::clear_role(RuntimeOrigin::signed(1), RoleType::Tss));
 
 		// Role should be removed from  account role mappings.
-		assert_eq!(Roles::account_role(1), None);
+		assert_eq!(Roles::has_role(1, RoleType::Tss), false);
 
 		// unbound funds.
 		assert_ok!(Roles::unbound_funds(RuntimeOrigin::signed(1), 5000));
@@ -152,7 +178,7 @@ fn test_unbound_funds_should_fail_if_role_assigned() {
 		));
 
 		// Lets verify role is assigned to account.
-		assert_eq!(Roles::account_role(1), Some(RoleType::Tss));
+		assert_eq!(Roles::has_role(1, RoleType::Tss), true);
 
 		// Lets try to unbound funds.
 		assert_err!(


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- [x] Support multiple roles
        - User can select multiple roles
        - User has a limit on re-staking (currently 50 % of total staked value)
        -  Each role has a minimum re-stake requirement.
        -  After assigning roles `RolestakingLedger` will be updated with the selected roles and staking record

- [x] Add and update tests

---
 ### Account Roles Mapping for storing multiple roles
```rust
pub type AccountRolesMapping<T: Config> = StorageMap<
		_,
		Blake2_256,
		T::AccountId,
		BoundedVec<RoleType, T::MaxRolesPerAccount>,
		ValueQuery,
	>;
```

### Role staking ledger structure for storing record.

```rust
#[scale_info(skip_type_params(T))]
pub struct RoleStakingLedger<T: Config> {
	/// The stash account whose balance is actually locked and at stake.
	pub stash: T::AccountId,
	/// The total amount of the stash's balance that is re-staked for all selected roles.
	/// This re-staked balance we are currently accounting for new slashing conditions.
	#[codec(compact)]
	pub total: BalanceOf<T>,
	/// The list of roles and their re-staked amounts.
	pub roles: Vec<RoleStakingRecord<T>>,
}

#[derive(PartialEqNoBound, EqNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo, Clone)]
#[scale_info(skip_type_params(T))]
pub struct RoleStakingRecord<T: Config> {
	/// Role type
	pub role: RoleType,
	/// The total amount of the stash's balance that is re-staked for the selected role.
	#[codec(compact)]
	pub re_staked: BalanceOf<T>,
}
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #305 
