### PR TITLE
Update Jobs Runtime API

### DIFF
--- a/pallets/jobs/rpc/runtime-api/src/lib.rs
+++ b/pallets/jobs/rpc/runtime-api/src/lib.rs
@@ -20,9 +20,7 @@
 use parity_scale_codec::Codec;
 use sp_runtime::{traits::MaybeDisplay, Serialize};
 
-use pallet_jobs::types::JobInfoOf;
-pub use tangle_primitives::jobs::RpcResponseJobsData;
-use tangle_primitives::jobs::{JobId, JobKey, RpcResponsePhaseOneResult};
+use tangle_primitives::jobs::{JobId, JobKey, RpcResponseJobsData, RpcResponsePhaseOneResult};
 
 sp_api::decl_runtime_apis! {
 	pub trait JobsApi<AccountId> where

--- a/pallets/jobs/rpc/runtime-api/src/lib.rs
+++ b/pallets/jobs/rpc/runtime-api/src/lib.rs
@@ -20,7 +20,9 @@
 use parity_scale_codec::Codec;
 use sp_runtime::{traits::MaybeDisplay, Serialize};
 
+use pallet_jobs::types::JobInfoOf;
 pub use tangle_primitives::jobs::RpcResponseJobsData;
+use tangle_primitives::jobs::{JobId, JobKey, RpcResponsePhaseOneResult};
 
 sp_api::decl_runtime_apis! {
 	pub trait JobsApi<AccountId> where
@@ -42,5 +44,34 @@ sp_api::decl_runtime_apis! {
 		/// Returns a `Result` containing a vector of `RpcResponseJobsData<AccountId>` if the
 		/// operation is successful
 		fn query_jobs_by_validator(validator: AccountId) -> Result<Vec<RpcResponseJobsData<AccountId>>, String>;
+		/// Queries a job by its key and ID.
+		///
+		/// # Arguments
+		///
+		/// * `job_key` - The key of the job.
+		/// * `job_id` - The ID of the job.
+		///
+		/// # Returns
+		///
+		/// An optional `RpcResponseJobsData` containing the account ID of the job.
+		fn query_job_by_id(job_key: JobKey, job_id: JobId) -> Option<RpcResponseJobsData<AccountId>>;
+
+		/// Queries the phase one result of a job by its key and ID.
+		///
+		/// # Arguments
+		///
+		/// * `job_key` - The key of the job.
+		/// * `job_id` - The ID of the job.
+		///
+		/// # Returns
+		///
+		/// An `Option` containing the phase one result of the job, wrapped in an `RpcResponsePhaseOneResult`.
+		fn query_phase_one_by_id(job_key: JobKey, job_id: JobId) -> Option<RpcResponsePhaseOneResult<AccountId>>;
+
+		/// Queries next job ID.
+		///
+		///  # Returns
+		///  Next job ID.
+		fn query_next_job_id() -> JobId;
 	}
 }

--- a/primitives/src/types/jobs.rs
+++ b/primitives/src/types/jobs.rs
@@ -383,6 +383,21 @@ pub struct RpcResponseJobsData<AccountId> {
 
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub struct RpcResponsePhaseOneResult<AccountId> {
+	/// The owner's account ID.
+	pub owner: AccountId,
+	/// The type of the job result.
+	pub result: Vec<u8>,
+	/// permitted caller to use this result
+	pub permitted_caller: Option<AccountId>,
+	/// Key type if applicable
+	pub key_type: Option<DkgKeyType>,
+	/// The type of the job submission.
+	pub job_type: JobType<AccountId>,
+}
+
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum JobResult {
 	DKGPhaseOne(DKGResult),
 


### PR DESCRIPTION
This Runtime API is needed for gadgets, not for RPC as it exposes methods/read-only for the storage in the jobs pallet.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #349 
