### PR TITLE
bugfix: Fix claims pallet

### DIFF
--- a/node/src/chainspec/mainnet.rs
+++ b/node/src/chainspec/mainnet.rs
@@ -122,7 +122,6 @@ pub fn local_mainnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 					mainnet::get_edgeware_genesis_balance_distribution(),
 					mainnet::get_leaderboard_balance_distribution(),
 					mainnet::get_substrate_balance_distribution(),
-					mainnet::get_local_balance_distribution(),
 				]),
 				// Genesis investor / team distribution (pallet-balances + pallet-vesting)
 				combine_distributions(vec![

--- a/node/src/chainspec/testnet.rs
+++ b/node/src/chainspec/testnet.rs
@@ -129,6 +129,7 @@ pub fn local_testnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 					testnet::get_evm_balance_distribution(),
 				]),
 				testnet::get_substrate_balance_distribution(),
+				develop::get_evm_claims(),
 				true,
 			)
 		},
@@ -202,6 +203,7 @@ pub fn tangle_testnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 					testnet::get_evm_balance_distribution(),
 				]),
 				testnet::get_substrate_balance_distribution(),
+				vec![],
 				true,
 			)
 		},
@@ -231,6 +233,7 @@ fn testnet_genesis(
 	chain_id: u64,
 	genesis_evm_distribution: Vec<(H160, fp_evm::GenesisAccount)>,
 	genesis_substrate_distribution: Vec<(AccountId, Balance)>,
+	claims: Vec<(MultiAddress, Balance)>,
 	_enable_println: bool,
 ) -> RuntimeGenesisConfig {
 	const ENDOWMENT: Balance = 10_000_000 * UNIT;
@@ -258,6 +261,7 @@ fn testnet_genesis(
 	let claims: Vec<(MultiAddress, Balance, Option<StatementKind>)> = endowed_accounts
 		.iter()
 		.map(|x| (MultiAddress::Native(x.clone()), ENDOWMENT, Some(StatementKind::Regular)))
+		.chain(claims.into_iter().map(|(a, b)| (a, b, Some(StatementKind::Regular))))
 		.collect();
 	let vesting_claims: Vec<(
 		MultiAddress,

--- a/node/src/distributions/develop.rs
+++ b/node/src/distributions/develop.rs
@@ -18,9 +18,10 @@ use std::str::FromStr;
 use fp_evm::GenesisAccount;
 use pallet_airdrop_claims::MultiAddress;
 use sp_core::{H160, U256};
+use sp_runtime::AccountId32;
 use tangle_primitives::Balance;
 
-pub fn get_evm_claims() -> Vec<(MultiAddress, Balance)> {
+pub fn get_local_claims() -> Vec<(MultiAddress, Balance)> {
 	vec![
 		// Test account with a simple menmonic
 		// Mnemonic: "test test test test test test test test test test test junk"
@@ -30,6 +31,30 @@ pub fn get_evm_claims() -> Vec<(MultiAddress, Balance)> {
 			MultiAddress::EVM(
 				H160::from_str("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
 					.expect("internal H160 is valid; qed")
+					.into(),
+			),
+			1_000_000_000_000_000_000_000_000u128,
+		),
+		(
+			MultiAddress::EVM(
+				H160::from_str("2DFA35bd8C59C38FB3eC4e71b0106160E130A40E")
+					.expect("internal H160 is valid; qed")
+					.into(),
+			),
+			1_000_000_000_000_000_000_000_000u128,
+		),
+		(
+			MultiAddress::Native(
+				AccountId32::from_str("5EbkKKTdRJzP1j3aM3S7q178du6tW7ZVWK9Dtjx9CbTFEpGf")
+					.expect("internal AccountId32 is valid; qed")
+					.into(),
+			),
+			1_000_000_000_000_000_000_000_000u128,
+		),
+		(
+			MultiAddress::Native(
+				AccountId32::from_str("5DLXgUoVVeCZKHduaVhkH4RvLcyG1GdQwLqYLd4aFuYX1qve")
+					.expect("internal AccountId32 is valid; qed")
 					.into(),
 			),
 			1_000_000_000_000_000_000_000_000u128,

--- a/node/src/distributions/develop.rs
+++ b/node/src/distributions/develop.rs
@@ -16,7 +16,26 @@
 use std::str::FromStr;
 
 use fp_evm::GenesisAccount;
+use pallet_airdrop_claims::MultiAddress;
 use sp_core::{H160, U256};
+use tangle_primitives::Balance;
+
+pub fn get_evm_claims() -> Vec<(MultiAddress, Balance)> {
+	vec![
+		// Test account with a simple menmonic
+		// Mnemonic: "test test test test test test test test test test test junk"
+		// Path: m/44'/60'/0'/0/0
+		// Private Key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+		(
+			MultiAddress::EVM(
+				H160::from_str("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
+					.expect("internal H160 is valid; qed")
+					.into(),
+			),
+			1_000_000_000_000_000_000_000_000u128,
+		),
+	]
+}
 
 pub fn get_evm_balance_distribution() -> Vec<(H160, GenesisAccount)> {
 	vec![

--- a/node/src/distributions/mainnet.rs
+++ b/node/src/distributions/mainnet.rs
@@ -165,45 +165,6 @@ pub fn get_leaderboard_balance_distribution() -> DistributionResult {
 	)
 }
 
-/// Used for testing purposes
-///
-/// DO NOT USE IN MAINNET
-pub fn get_local_balance_distribution() -> DistributionResult {
-	let list = vec![
-		// Test account with a simple menmonic
-		// Mnemonic: "test test test test test test test test test test test junk"
-		// Path: m/44'/60'/0'/0/0
-		// Private Key: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
-		H160::from_str("f39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
-			.expect("internal H160 is valid; qed"),
-		// Test account with a simple menmonic
-		// Mnemonic: "test test test test test test test test test test test junk"
-		// Path: m/44'/60'/0'/0/1
-		// Private Key: 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d
-		H160::from_str("70997970C51812dc3A010C7d01b50e0d17dc79C8")
-			.expect("internal H160 is valid; qed"),
-		// H160 address of Alice dev account
-		// Derived from SS58 (42 prefix) address
-		// SS58: 5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-		// hex: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
-		// Using the full hex key, truncating to the first 20 bytes (the first 40 hex
-		// chars)
-		H160::from_str("d43593c715fdd31c61141abd04a99fd6822c8558")
-			.expect("internal H160 is valid; qed"),
-	];
-	let endowment = ONE_PERCENT_TOTAL_SUPPLY / list.len() as u128;
-	let local_list: Vec<(MultiAddress, u128)> = list
-		.into_iter()
-		.map(|address| (MultiAddress::EVM(EthereumAddress(address.0)), endowment))
-		.collect();
-	get_distribution_for(
-		local_list,
-		Some(StatementKind::Regular),
-		ONE_MONTH_BLOCKS,
-		TWO_YEARS_BLOCKS,
-	)
-}
-
 pub fn get_substrate_balance_distribution() -> DistributionResult {
 	let arr = get_edgeware_snapshot_list()
 		.into_iter()

--- a/pallets/claims/src/tests.rs
+++ b/pallets/claims/src/tests.rs
@@ -81,7 +81,11 @@ fn claiming_works() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
 			None,
-			sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+			sig::<Test>(
+				&alice(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_eq!(
 			Balances::free_balance(&get_multi_address_account_id(42).to_account_id_32()),
@@ -117,7 +121,11 @@ fn basic_claim_moving_works() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+				sig::<Test>(
+					&alice(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::SignerHasNoClaim
 		);
@@ -125,7 +133,11 @@ fn basic_claim_moving_works() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
 			None,
-			sig::<Test>(&bob(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+			sig::<Test>(
+				&bob(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_eq!(
 			Balances::free_balance(&get_multi_address_account_id(42).to_account_id_32()),
@@ -149,7 +161,7 @@ fn claim_attest_moving_works() {
 		));
 		let s = sig::<Test>(
 			&bob(),
-			&Some(get_multi_address_account_id(42)).encode(),
+			&get_multi_address_account_id(42).to_account_id_32().encode(),
 			StatementKind::Regular.to_text(),
 		);
 		assert_ok!(ClaimsPallet::claim_attest(
@@ -173,14 +185,22 @@ fn claiming_does_not_bypass_signing() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
 			None,
-			sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+			sig::<Test>(
+				&alice(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_noop!(
 			ClaimsPallet::claim(
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&dave(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+				sig::<Test>(
+					&dave(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::InvalidStatement,
 		);
@@ -189,7 +209,11 @@ fn claiming_does_not_bypass_signing() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&eve(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+				sig::<Test>(
+					&eve(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::InvalidStatement,
 		);
@@ -197,7 +221,11 @@ fn claiming_does_not_bypass_signing() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
 			None,
-			sig::<Test>(&frank(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+			sig::<Test>(
+				&frank(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 	});
 }
@@ -206,7 +234,7 @@ fn claiming_does_not_bypass_signing() {
 fn attest_claiming_works() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Balances::free_balance(get_multi_address_account_id(42).to_account_id_32()), 0);
-		let data = Some(get_multi_address_account_id(42)).encode();
+		let data = get_multi_address_account_id(42).to_account_id_32().encode();
 		let s = sig::<Test>(&dave(), &data, StatementKind::Safe.to_text());
 		let r = ClaimsPallet::claim_attest(
 			RuntimeOrigin::none(),
@@ -230,7 +258,7 @@ fn attest_claiming_works() {
 
 		let s = sig::<Test>(
 			&dave(),
-			&Some(get_multi_address_account_id(42)).encode(),
+			&get_multi_address_account_id(42).to_account_id_32().encode(),
 			StatementKind::Regular.to_text(),
 		);
 		assert_ok!(ClaimsPallet::claim_attest(
@@ -248,7 +276,7 @@ fn attest_claiming_works() {
 
 		let s = sig::<Test>(
 			&dave(),
-			&Some(get_multi_address_account_id(42)).encode(),
+			&get_multi_address_account_id(42).to_account_id_32().encode(),
 			StatementKind::Regular.to_text(),
 		);
 		let r = ClaimsPallet::claim_attest(
@@ -266,7 +294,11 @@ fn attest_claiming_works() {
 fn cannot_bypass_attest_claiming() {
 	new_test_ext().execute_with(|| {
 		assert_eq!(Balances::free_balance(get_multi_address_account_id(42).to_account_id_32()), 0);
-		let s = sig::<Test>(&dave(), &Some(get_multi_address_account_id(42)).encode(), &[]);
+		let s = sig::<Test>(
+			&dave(),
+			&get_multi_address_account_id(42).to_account_id_32().encode(),
+			&[],
+		);
 		let r = ClaimsPallet::claim(
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
@@ -296,7 +328,11 @@ fn add_claim_works() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(69)),
 				None,
-				sig::<Test>(&bob(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+				sig::<Test>(
+					&bob(),
+					&get_multi_address_account_id(69).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::SignerHasNoClaim,
 		);
@@ -306,7 +342,11 @@ fn add_claim_works() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(69)),
 			None,
-			sig::<Test>(&bob(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+			sig::<Test>(
+				&bob(),
+				&get_multi_address_account_id(69).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_eq!(
 			Balances::free_balance(get_multi_address_account_id(69).to_account_id_32()),
@@ -339,7 +379,11 @@ fn add_claim_with_vesting_works() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(69)),
 				None,
-				sig::<Test>(&bob(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+				sig::<Test>(
+					&bob(),
+					&get_multi_address_account_id(69).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::SignerHasNoClaim,
 		);
@@ -354,7 +398,11 @@ fn add_claim_with_vesting_works() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(69)),
 			None,
-			sig::<Test>(&bob(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+			sig::<Test>(
+				&bob(),
+				&get_multi_address_account_id(69).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_eq!(
 			Balances::free_balance(get_multi_address_account_id(69).to_account_id_32()),
@@ -394,7 +442,7 @@ fn add_claim_with_statement_works() {
 		assert_eq!(Balances::free_balance(get_multi_address_account_id(42).to_account_id_32()), 0);
 		let signature = sig::<Test>(
 			&bob(),
-			&Some(get_multi_address_account_id(69)).encode(),
+			&get_multi_address_account_id(69).to_account_id_32().encode(),
 			StatementKind::Regular.to_text(),
 		);
 
@@ -448,7 +496,11 @@ fn origin_signed_claiming_fail() {
 				RuntimeOrigin::signed(get_multi_address_account_id(42).to_account_id_32()),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+				sig::<Test>(
+					&alice(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			sp_runtime::traits::BadOrigin,
 		);
@@ -463,14 +515,22 @@ fn double_claiming_doesnt_work() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
 			None,
-			sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+			sig::<Test>(
+				&alice(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_noop!(
 			ClaimsPallet::claim(
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+				sig::<Test>(
+					&alice(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::SignerHasNoClaim
 		);
@@ -511,7 +571,11 @@ fn claiming_while_vested_doesnt_work() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(69)),
 				None,
-				sig::<Test>(&bob(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+				sig::<Test>(
+					&bob(),
+					&get_multi_address_account_id(69).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::VestedBalanceExists,
 		);
@@ -527,7 +591,11 @@ fn non_sender_sig_doesnt_work() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&alice(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+				sig::<Test>(
+					&alice(),
+					&get_multi_address_account_id(69).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::SignerHasNoClaim
 		);
@@ -543,7 +611,11 @@ fn non_claimant_doesnt_work() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&bob(), &Some(get_multi_address_account_id(69)).encode(), &[][..])
+				sig::<Test>(
+					&bob(),
+					&get_multi_address_account_id(69).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::SignerHasNoClaim
 		);
@@ -576,7 +648,7 @@ fn validate_unsigned_works() {
 					signer: None,
 					signature: sig::<Test>(
 						&alice(),
-						&Some(get_multi_address_account_id(1)).encode(),
+						&get_multi_address_account_id(1).to_account_id_32().encode(),
 						&[][..]
 					)
 				}
@@ -608,7 +680,7 @@ fn validate_unsigned_works() {
 					signer: None,
 					signature: sig::<Test>(
 						&bob(),
-						&Some(get_multi_address_account_id(1)).encode(),
+						&get_multi_address_account_id(1).to_account_id_32().encode(),
 						&[][..]
 					)
 				}
@@ -617,7 +689,7 @@ fn validate_unsigned_works() {
 		);
 		let s = sig::<Test>(
 			&dave(),
-			&Some(get_multi_address_account_id(1)).encode(),
+			&get_multi_address_account_id(1).to_account_id_32().encode(),
 			StatementKind::Regular.to_text(),
 		);
 		let call = ClaimsCall::claim_attest {
@@ -651,7 +723,7 @@ fn validate_unsigned_works() {
 
 		let s = sig::<Test>(
 			&bob(),
-			&Some(get_multi_address_account_id(1)).encode(),
+			&get_multi_address_account_id(1).to_account_id_32().encode(),
 			StatementKind::Regular.to_text(),
 		);
 		let call = ClaimsCall::claim_attest {
@@ -667,7 +739,7 @@ fn validate_unsigned_works() {
 
 		let s = sig::<Test>(
 			&dave(),
-			&Some(get_multi_address_account_id(1)).encode(),
+			&get_multi_address_account_id(1).to_account_id_32().encode(),
 			StatementKind::Safe.to_text(),
 		);
 		let call = ClaimsCall::claim_attest {
@@ -683,7 +755,7 @@ fn validate_unsigned_works() {
 
 		let s = sig::<Test>(
 			&dave(),
-			&Some(get_multi_address_account_id(1)).encode(),
+			&get_multi_address_account_id(1).to_account_id_32().encode(),
 			StatementKind::Safe.to_text(),
 		);
 		let call = ClaimsCall::claim_attest {
@@ -708,7 +780,11 @@ fn test_unclaimed_returned_to_destination() {
 			RuntimeOrigin::none(),
 			Some(get_multi_address_account_id(42)),
 			None,
-			sig::<Test>(&alice(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+			sig::<Test>(
+				&alice(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
+				&[][..]
+			)
 		));
 		assert_eq!(Total::<Test>::get(), original_total_claims - claim_of_alice);
 
@@ -735,7 +811,11 @@ fn test_unclaimed_returned_to_destination() {
 				RuntimeOrigin::none(),
 				Some(get_multi_address_account_id(42)),
 				None,
-				sig::<Test>(&frank(), &Some(get_multi_address_account_id(42)).encode(), &[][..])
+				sig::<Test>(
+					&frank(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
+					&[][..]
+				)
 			),
 			Error::<Test>::PotUnderflow
 		);
@@ -753,7 +833,7 @@ fn test_claim_from_substrate_address_to_evm() {
 			Some(sr25519_utils::sub(&alice_sr25519())),
 			sr25519_utils::sig::<Test>(
 				&alice_sr25519(),
-				&Some(get_multi_address_account_id(42)).encode(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
 				&[][..]
 			)
 		));
@@ -770,7 +850,7 @@ fn test_claim_from_substrate_address_to_evm() {
 				None,
 				sr25519_utils::sig::<Test>(
 					&bob_sr25519(),
-					&Some(get_multi_address_account_id(42)).encode(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
 					&[][..]
 				)
 			),
@@ -801,7 +881,7 @@ fn test_claim_from_substrate_address_to_evm() {
 				Some(sr25519_utils::sub(&bob_sr25519())),
 				sr25519_utils::sig::<Test>(
 					&bob_sr25519(),
-					&Some(get_multi_address_account_id(42)).encode(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
 					&[][..]
 				)
 			),
@@ -821,7 +901,7 @@ fn test_double_claim_fails_for_substrate_account() {
 			Some(sr25519_utils::sub(&alice_sr25519())),
 			sr25519_utils::sig::<Test>(
 				&alice_sr25519(),
-				&Some(get_multi_address_account_id(42)).encode(),
+				&get_multi_address_account_id(42).to_account_id_32().encode(),
 				&[][..]
 			)
 		));
@@ -838,7 +918,7 @@ fn test_double_claim_fails_for_substrate_account() {
 				Some(sr25519_utils::sub(&alice_sr25519())),
 				sr25519_utils::sig::<Test>(
 					&alice_sr25519(),
-					&Some(get_multi_address_account_id(42)).encode(),
+					&get_multi_address_account_id(42).to_account_id_32().encode(),
 					&[][..]
 				)
 			),

--- a/pallets/claims/src/utils/ethereum_address.rs
+++ b/pallets/claims/src/utils/ethereum_address.rs
@@ -47,6 +47,14 @@ impl From<EthereumAddress> for H160 {
 	}
 }
 
+impl From<H160> for EthereumAddress {
+	fn from(a: H160) -> Self {
+		let mut r = Self::default();
+		r.0.copy_from_slice(&a.0);
+		r
+	}
+}
+
 #[derive(Clone, Copy, Eq, Encode, Decode, TypeInfo)]
 pub struct EcdsaSignature(pub [u8; 65]);
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Update encoding for MultiAddress accounts (now we match over the type and only encode the inner value)
- Fix polkadotjs message format, by adding the prefix and suffix.

**Notes**
I did provide two examples for claims in both Native accounts and EVM accounts
- claim using EVM: https://gist.github.com/shekohex/6af3f02c3099bb031f8d952376904d9f
- claim using Native: https://gist.github.com/shekohex/8a1f3088a6df88275312bc30905c2ba0

cc @AtelyPham Lmk if you will need help integrating the new format. but the tl;dr is that we now do not need the codecPrefix (i.e `0x30313031`). Long version look into the [diff](https://gist.github.com/shekohex/6af3f02c3099bb031f8d952376904d9f/revisions#diff-161363d1881d5d13562032d6e060879a830a784cfa4c6ec4fcf22e8dddf78ce1).

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #393 

