### PR TITLE
feat : set address prefixes

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tangle"
 build = "build.rs"
-description = "Tangle Standalone chain node"
+description = "Tangle chain node"
 version = { workspace = true }
 authors = { workspace = true }
 edition = { workspace = true }

--- a/node/src/chainspec/mainnet.rs
+++ b/node/src/chainspec/mainnet.rs
@@ -92,7 +92,7 @@ pub fn local_mainnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "TNT".into());
 	properties.insert("tokenDecimals".into(), 18u32.into());
-	properties.insert("ss58Format".into(), 4006.into());
+	properties.insert("ss58Format".into(), tangle_primitives::MAINNET_SS58_PREFIX.into());
 
 	Ok(ChainSpec::from_genesis(
 		"Local Tangle Mainnet",
@@ -112,6 +112,9 @@ pub fn local_mainnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 					get_account_id_from_seed::<sr25519::Public>("Alice"),
 					get_account_id_from_seed::<sr25519::Public>("Bob"),
 					get_account_id_from_seed::<sr25519::Public>("Charlie"),
+					get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+					get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
 				],
 				// Sudo account
 				get_account_id_from_seed::<sr25519::Public>("Alice"),
@@ -151,7 +154,7 @@ pub fn tangle_mainnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "TNT".into());
 	properties.insert("tokenDecimals".into(), 18u32.into());
-	properties.insert("ss58Format".into(), 4006.into());
+	properties.insert("ss58Format".into(), tangle_primitives::MAINNET_SS58_PREFIX.into());
 
 	Ok(ChainSpec::from_genesis(
 		"Tangle Mainnet",

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -288,3 +288,11 @@ pub const MAXIMUM_BLOCK_WEIGHT: Weight =
 	Weight::from_parts(WEIGHT_REF_TIME_PER_SECOND, MAX_POV_SIZE as u64);
 
 pub use sp_consensus_babe::AuthorityId as BabeId;
+
+// 5845 this would give us addresses with tg prefix for mainnet like
+// tgGmBRR5yM53bvq8tTzgsUirpPtfCXngYYU7uiihmWFJhmYGM
+pub const MAINNET_SS58_PREFIX: u16 = 5845;
+
+// 3799 this would give us addresses with  tt prefix for testnet like
+// ttFELSU4MTyzpfsgZ9tFinrmox7pV7nF1BLbfYjsu4rfDYM74
+pub const TESTNET_SS58_PREFIX: u16 = 3799;

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -165,7 +165,7 @@ parameter_types! {
 		::with_sensible_defaults(MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(MAXIMUM_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO);
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u16 = tangle_primitives::MAINNET_SS58_PREFIX;
 }
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -177,7 +177,7 @@ parameter_types! {
 		::with_sensible_defaults(MAXIMUM_BLOCK_WEIGHT, NORMAL_DISPATCH_RATIO);
 	pub BlockLength: frame_system::limits::BlockLength = frame_system::limits::BlockLength
 		::max_with_normal_ratio(MAXIMUM_BLOCK_LENGTH, NORMAL_DISPATCH_RATIO);
-	pub const SS58Prefix: u8 = 42;
+	pub const SS58Prefix: u16 = tangle_primitives::TESTNET_SS58_PREFIX;
 }
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Setup ss58 address prefix for testnet/mainnet

for mainnet, `5845` this would give us addresses with tg prefix for mainnet like `tgGmBRR5yM53bvq8tTzgsUirpPtfCXngYYU7uiihmWFJhmYGM`
for testnet,  `3799` this would give us addresses with  tt prefix for testnet like `ttFELSU4MTyzpfsgZ9tFinrmox7pV7nF1BLbfYjsu4rfDYM74`

TODO : If approved, update in ss58 registry

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #388
