### PR TITLE
Store Role key while creating profile

### DIFF
--- a/pallets/jobs/src/functions.rs
+++ b/pallets/jobs/src/functions.rs
@@ -281,9 +281,9 @@ impl<T: Config> Pallet<T> {
 		let mut participant_keys: Vec<Vec<u8>> = Default::default();
 
 		for participant in participants.clone() {
-			let key = T::RolesHandler::get_validator_metadata(participant, role_type);
-			ensure!(key.is_some(), Error::<T>::ValidatorMetadataNotFound);
-			participant_keys.push(key.expect("checked above").get_authority_key());
+			let key = T::RolesHandler::get_validator_role_key(participant);
+			ensure!(key.is_some(), Error::<T>::ValidatorRoleKeyNotFound);
+			participant_keys.push(key.expect("checked above"));
 		}
 
 		let job_result = JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
@@ -337,12 +337,10 @@ impl<T: Config> Pallet<T> {
 
 		let participants = phase_one_result.participants().ok_or(Error::<T>::InvalidJobPhase)?;
 		for participant in participants {
-			let key = T::RolesHandler::get_validator_metadata(participant, role_type);
-			ensure!(key.is_some(), Error::<T>::ValidatorMetadataNotFound);
-			let pub_key = sp_core::ecdsa::Public::from_slice(
-				&key.expect("checked above").get_authority_key()[0..33],
-			)
-			.map_err(|_| Error::<T>::InvalidValidator)?;
+			let key = T::RolesHandler::get_validator_role_key(participant);
+			ensure!(key.is_some(), Error::<T>::ValidatorRoleKeyNotFound);
+			let pub_key = sp_core::ecdsa::Public::from_slice(&key.expect("checked above")[0..33])
+				.map_err(|_| Error::<T>::InvalidValidator)?;
 			participant_keys.push(pub_key);
 		}
 
@@ -392,12 +390,10 @@ impl<T: Config> Pallet<T> {
 		let mut participant_keys: Vec<sp_core::ecdsa::Public> = Default::default();
 
 		for participant in participants.clone() {
-			let key = T::RolesHandler::get_validator_metadata(participant, role_type);
-			ensure!(key.is_some(), Error::<T>::ValidatorMetadataNotFound);
-			let pub_key = sp_core::ecdsa::Public::from_slice(
-				&key.expect("checked above").get_authority_key()[0..33],
-			)
-			.map_err(|_| Error::<T>::InvalidValidator)?;
+			let key = T::RolesHandler::get_validator_role_key(participant);
+			ensure!(key.is_some(), Error::<T>::ValidatorRoleKeyNotFound);
+			let pub_key = sp_core::ecdsa::Public::from_slice(&key.expect("checked above")[0..33])
+				.map_err(|_| Error::<T>::InvalidValidator)?;
 			participant_keys.push(pub_key);
 		}
 

--- a/pallets/jobs/src/lib.rs
+++ b/pallets/jobs/src/lib.rs
@@ -117,8 +117,8 @@ pub mod module {
 		EmptyResult,
 		/// empty job
 		EmptyJob,
-		/// Validator metadata not found
-		ValidatorMetadataNotFound,
+		/// Validator role key not found.
+		ValidatorRoleKeyNotFound,
 		/// Unexpected result provided
 		ResultNotExpectedType,
 		/// No permission to change permitted caller

--- a/pallets/jobs/src/mock.rs
+++ b/pallets/jobs/src/mock.rs
@@ -30,11 +30,7 @@ use sp_core::ecdsa;
 use sp_io::crypto::ecdsa_generate;
 use sp_keystore::{testing::MemoryKeystore, KeystoreExt, KeystorePtr};
 use sp_std::sync::Arc;
-use tangle_primitives::{
-	currency::UNIT,
-	jobs::*,
-	roles::{RoleType, RoleTypeMetadata, TssRoleMetadata},
-};
+use tangle_primitives::{currency::UNIT, jobs::*, roles::RoleType};
 
 impl frame_system::Config for Runtime {
 	type RuntimeOrigin = RuntimeOrigin;
@@ -133,22 +129,12 @@ impl RolesHandler<AccountId32> for MockRolesHandler {
 		Ok(())
 	}
 
-	fn get_validator_metadata(
-		address: AccountId32,
-		role_type: RoleType,
-	) -> Option<RoleTypeMetadata> {
+	fn get_validator_role_key(address: AccountId32) -> Option<Vec<u8>> {
 		let mock_err_account = AccountId32::new([100u8; 32]);
 		if address == mock_err_account {
 			None
 		} else {
-			match role_type {
-				RoleType::Tss(threshold_signature_role) =>
-					Some(RoleTypeMetadata::Tss(TssRoleMetadata {
-						role_type: threshold_signature_role,
-						authority_key: mock_pub_key().to_raw_vec(),
-					})),
-				_ => None,
-			}
+			Some(mock_pub_key().to_raw_vec())
 		}
 	}
 }

--- a/pallets/roles/src/profile.rs
+++ b/pallets/roles/src/profile.rs
@@ -18,14 +18,14 @@ use crate::{BalanceOf, Config};
 use frame_support::pallet_prelude::*;
 use sp_runtime::traits::Zero;
 use sp_std::vec::Vec;
-use tangle_primitives::roles::{RoleType, RoleTypeMetadata};
+use tangle_primitives::roles::RoleType;
 
 #[derive(
 	PartialEqNoBound, EqNoBound, CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo,
 )]
 #[scale_info(skip_type_params(T))]
 pub struct Record<T: Config> {
-	pub metadata: RoleTypeMetadata,
+	pub role: RoleType,
 	pub amount: Option<BalanceOf<T>>,
 }
 
@@ -89,23 +89,18 @@ impl<T: Config> Profile<T> {
 	pub fn get_roles(&self) -> Vec<RoleType> {
 		match self {
 			Profile::Independent(profile) =>
-				profile.records.iter().map(|record| record.metadata.get_role_type()).collect(),
-			Profile::Shared(profile) =>
-				profile.records.iter().map(|record| record.metadata.get_role_type()).collect(),
+				profile.records.iter().map(|record| record.role).collect(),
+			Profile::Shared(profile) => profile.records.iter().map(|record| record.role).collect(),
 		}
 	}
 
 	/// Checks if the profile contains given role.
 	pub fn has_role(&self, role_type: RoleType) -> bool {
 		match self {
-			Profile::Independent(profile) => profile
-				.records
-				.iter()
-				.any(|record| record.metadata.get_role_type() == role_type),
-			Profile::Shared(profile) => profile
-				.records
-				.iter()
-				.any(|record| record.metadata.get_role_type() == role_type),
+			Profile::Independent(profile) =>
+				profile.records.iter().any(|record| record.role == role_type),
+			Profile::Shared(profile) =>
+				profile.records.iter().any(|record| record.role == role_type),
 		}
 	}
 
@@ -113,10 +108,10 @@ impl<T: Config> Profile<T> {
 	pub fn remove_role_from_profile(&mut self, role_type: RoleType) {
 		match self {
 			Profile::Independent(profile) => {
-				profile.records.retain(|record| record.metadata.get_role_type() != role_type);
+				profile.records.retain(|record| record.role != role_type);
 			},
 			Profile::Shared(profile) => {
-				profile.records.retain(|record| record.metadata.get_role_type() != role_type);
+				profile.records.retain(|record| record.role != role_type);
 			},
 		}
 	}

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -60,7 +60,7 @@ fn test_create_independent_profile() {
 		// Get the ledger to check if the profile is created.
 		let ledger = Roles::ledger(mock_pub_key(1)).unwrap();
 		assert_eq!(ledger.profile, profile);
-		assert!(ledger.profile.is_independent());
+		assert!(ledger.profile.is_shared());
 	});
 }
 

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -20,13 +20,19 @@ use frame_support::{assert_err, assert_ok, BoundedVec};
 use mock::*;
 use profile::{IndependentRestakeProfile, Record, SharedRestakeProfile};
 use sp_std::{default::Default, vec};
-use tangle_primitives::jobs::ReportValidatorOffence;
+use tangle_primitives::{
+	jobs::ReportValidatorOffence,
+	roles::{ThresholdSignatureRoleType, ZeroKnowledgeRoleType},
+};
 
 pub fn independent_profile() -> Profile<Runtime> {
 	let profile = IndependentRestakeProfile {
 		records: BoundedVec::try_from(vec![
-			Record { metadata: RoleTypeMetadata::Tss(Default::default()), amount: Some(2500) },
-			Record { metadata: RoleTypeMetadata::ZkSaas(Default::default()), amount: Some(2500) },
+			Record { role: RoleType::Tss(ThresholdSignatureRoleType::TssGG20), amount: Some(2500) },
+			Record {
+				role: RoleType::ZkSaaS(ZeroKnowledgeRoleType::ZkSaaSGroth16),
+				amount: Some(2500),
+			},
 		])
 		.unwrap(),
 	};
@@ -36,8 +42,8 @@ pub fn independent_profile() -> Profile<Runtime> {
 pub fn shared_profile() -> Profile<Runtime> {
 	let profile = SharedRestakeProfile {
 		records: BoundedVec::try_from(vec![
-			Record { metadata: RoleTypeMetadata::Tss(Default::default()), amount: None },
-			Record { metadata: RoleTypeMetadata::ZkSaas(Default::default()), amount: None },
+			Record { role: RoleType::Tss(ThresholdSignatureRoleType::TssGG20), amount: None },
+			Record { role: RoleType::ZkSaaS(ZeroKnowledgeRoleType::ZkSaaSGroth16), amount: None },
 		])
 		.unwrap(),
 		amount: 5000,
@@ -118,8 +124,11 @@ fn test_create_profile_should_fail_if_min_required_restake_condition_is_not_met(
 
 		let profile = Profile::Shared(SharedRestakeProfile {
 			records: BoundedVec::try_from(vec![
-				Record { metadata: RoleTypeMetadata::Tss(Default::default()), amount: None },
-				Record { metadata: RoleTypeMetadata::ZkSaas(Default::default()), amount: None },
+				Record { role: RoleType::Tss(ThresholdSignatureRoleType::TssGG20), amount: None },
+				Record {
+					role: RoleType::ZkSaaS(ZeroKnowledgeRoleType::ZkSaaSGroth16),
+					amount: None,
+				},
 			])
 			.unwrap(),
 			amount: 1000,
@@ -143,9 +152,12 @@ fn test_create_profile_should_fail_if_min_required_restake_condition_is_not_met_
 
 		let profile = Profile::Independent(IndependentRestakeProfile {
 			records: BoundedVec::try_from(vec![
-				Record { metadata: RoleTypeMetadata::Tss(Default::default()), amount: Some(1000) },
 				Record {
-					metadata: RoleTypeMetadata::ZkSaas(Default::default()),
+					role: RoleType::Tss(ThresholdSignatureRoleType::TssGG20),
+					amount: Some(1000),
+				},
+				Record {
+					role: RoleType::ZkSaaS(ZeroKnowledgeRoleType::ZkSaaSGroth16),
 					amount: Some(1000),
 				},
 			])

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -60,7 +60,7 @@ fn test_create_independent_profile() {
 		// Get the ledger to check if the profile is created.
 		let ledger = Roles::ledger(mock_pub_key(1)).unwrap();
 		assert_eq!(ledger.profile, profile);
-		assert!(ledger.profile.is_shared());
+		assert!(ledger.profile.is_independent());
 	});
 }
 

--- a/precompiles/jobs/src/mock.rs
+++ b/precompiles/jobs/src/mock.rs
@@ -30,7 +30,7 @@ use tangle_primitives::{
 		traits::{JobToFee, MPCHandler},
 		*,
 	},
-	roles::{traits::RolesHandler, RoleTypeMetadata},
+	roles::traits::RolesHandler,
 };
 
 pub type AccountId = MockAccount;
@@ -203,10 +203,7 @@ impl RolesHandler<AccountId> for MockRolesHandler {
 		validators.contains(&address)
 	}
 
-	fn get_validator_metadata(
-		_address: AccountId,
-		_role_type: RoleType,
-	) -> Option<RoleTypeMetadata> {
+	fn get_validator_role_key(_address: AccountId) -> Option<Vec<u8>> {
 		None
 	}
 

--- a/primitives/src/roles/traits.rs
+++ b/primitives/src/roles/traits.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{jobs::ReportValidatorOffence, roles::RoleTypeMetadata};
+use crate::jobs::ReportValidatorOffence;
 use sp_runtime::DispatchResult;
+use sp_std::vec::Vec;
 
 use super::RoleType;
 
@@ -44,16 +45,15 @@ pub trait RolesHandler<AccountId> {
 	/// Returns Ok() if validator offence report is submitted successfully.
 	fn report_offence(offence_report: ReportValidatorOffence<AccountId>) -> DispatchResult;
 
-	/// Retrieves metadata information for a validator associated with a specific job key.
+	/// Retrieves role key associated with given validator
 	///
 	/// # Arguments
 	///
-	/// * `address` - The account ID of the validator for which metadata is to be retrieved.
-	/// * `role_type` - The role data associated with the validator.
+	/// * `address` - The account ID of the validator for which role key is to be retrieved.
 	///
 	/// # Returns
 	///
-	/// Returns an `Option<RoleTypeMetadata>` containing metadata information for the specified
-	/// validator, or `None` if no metadata is found.
-	fn get_validator_metadata(address: AccountId, role_type: RoleType) -> Option<RoleTypeMetadata>;
+	/// Returns an `Option<Vec<u8>>` containing role key information for the specified
+	/// validator, or `None` if no role key is found.
+	fn get_validator_role_key(address: AccountId) -> Option<Vec<u8>>;
 }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- [x] Store role key on profile
- [x] Update traits and impl to return role key
- [x] Update tests


### Note
Removed metadata part for now since it is just role key. We will need to figure out a good way to take additional metadata user input for multiple different role types. cc: @1xstj 



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #374 
