### PR TITLE
chore: update chain ids

### DIFF
--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -73,15 +73,23 @@ impl SubstrateCli for Cli {
 
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
-			"" | "dev" | "local" => Box::new(chainspec::testnet::local_testnet_config(4007)?),
+			"" | "dev" | "local" => Box::new(chainspec::testnet::local_testnet_config(
+				tangle_primitives::TESTNET_CHAIN_ID,
+			)?),
 			// generates the spec for testnet
-			"testnet" => Box::new(chainspec::testnet::tangle_testnet_config(4007)?),
+			"testnet" => Box::new(chainspec::testnet::tangle_testnet_config(
+				tangle_primitives::TESTNET_CHAIN_ID,
+			)?),
 			"tangle-testnet" => Box::new(chainspec::testnet::ChainSpec::from_json_bytes(
 				&include_bytes!("../../chainspecs/testnet/tangle-standalone.json")[..],
 			)?),
 			// generates the spec for mainnet
-			"mainnet-local" => Box::new(chainspec::mainnet::local_mainnet_config(4006)?),
-			"mainnet" => Box::new(chainspec::mainnet::tangle_mainnet_config(4006)?),
+			"mainnet-local" => Box::new(chainspec::mainnet::local_mainnet_config(
+				tangle_primitives::MAINNET_CHAIN_ID,
+			)?),
+			"mainnet" => Box::new(chainspec::mainnet::tangle_mainnet_config(
+				tangle_primitives::MAINNET_CHAIN_ID,
+			)?),
 			path => Box::new(chainspec::testnet::ChainSpec::from_json_file(
 				std::path::PathBuf::from(path),
 			)?),

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -284,7 +284,9 @@ pub use sp_consensus_babe::AuthorityId as BabeId;
 // 5845 this would give us addresses with tg prefix for mainnet like
 // tgGmBRR5yM53bvq8tTzgsUirpPtfCXngYYU7uiihmWFJhmYGM
 pub const MAINNET_SS58_PREFIX: u16 = 5845;
+pub const MAINNET_CHAIN_ID: u64 = MAINNET_SS58_PREFIX as u64;
 
 // 3799 this would give us addresses with  tt prefix for testnet like
 // ttFELSU4MTyzpfsgZ9tFinrmox7pV7nF1BLbfYjsu4rfDYM74
 pub const TESTNET_SS58_PREFIX: u16 = 3799;
+pub const TESTNET_CHAIN_ID: u64 = TESTNET_SS58_PREFIX as u64;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Update chain id for testnet: `3799`
- Update chain id for mainnet: `5845`



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
