### PR TITLE
feat: Jobs TTL and Expiry

### DIFF
--- a/pallets/jobs/rpc/runtime-api/src/lib.rs
+++ b/pallets/jobs/rpc/runtime-api/src/lib.rs
@@ -25,6 +25,9 @@ use tangle_primitives::{
 	roles::RoleType,
 };
 
+pub type BlockNumberOf<Block> =
+	<<Block as sp_runtime::traits::HeaderProvider>::HeaderT as sp_runtime::traits::Header>::Number;
+
 sp_api::decl_runtime_apis! {
 	pub trait JobsApi<AccountId> where
 		AccountId: Codec + MaybeDisplay + Serialize,
@@ -33,7 +36,7 @@ sp_api::decl_runtime_apis! {
 		///
 		/// This function takes a `validator` parameter of type `AccountId` and attempts
 		/// to retrieve a list of jobs associated with the provided validator. If successful,
-		/// it constructs a vector of `RpcResponseJobsData<AccountId>` containing information
+		/// it constructs a vector of `RpcResponseJobsData` containing information
 		/// about the jobs and returns it as a `Result`.
 		///
 		/// # Arguments
@@ -43,7 +46,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		///
 		/// An optional vec of `RpcResponseJobsData` of jobs assigned to validator
-		fn query_jobs_by_validator(validator: AccountId) -> Option<Vec<RpcResponseJobsData<AccountId>>>;
+		fn query_jobs_by_validator(validator: AccountId) -> Option<Vec<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>>>;
 		/// Queries a job by its key and ID.
 		///
 		/// # Arguments
@@ -54,7 +57,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		///
 		/// An optional `RpcResponseJobsData` containing the account ID of the job.
-		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId>>;
+		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>>;
 
 		/// Queries the phase one result of a job by its key and ID.
 		///
@@ -66,7 +69,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		///
 		/// An `Option` containing the phase one result of the job, wrapped in an `RpcResponsePhaseOneResult`.
-		fn query_phase_one_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponsePhaseOneResult<AccountId>>;
+		fn query_phase_one_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponsePhaseOneResult<AccountId, BlockNumberOf<Block>>>;
 
 		/// Queries next job ID.
 		///

--- a/pallets/jobs/src/tests.rs
+++ b/pallets/jobs/src/tests.rs
@@ -45,7 +45,8 @@ fn jobs_submission_e2e_works_for_dkg() {
 
 		let threshold_signature_role_type = ThresholdSignatureRoleType::TssGG20;
 		let submission = JobSubmission {
-			expiry: 100,
+			expiry: 10,
+			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
 				participants: vec![HUNDRED, BOB, CHARLIE, DAVE, EVE],
 				threshold: 3,
@@ -61,7 +62,8 @@ fn jobs_submission_e2e_works_for_dkg() {
 		);
 
 		let submission = JobSubmission {
-			expiry: 100,
+			expiry: 10,
+			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
 				participants: vec![ALICE, BOB, CHARLIE, DAVE, EVE],
 				threshold: 5,
@@ -78,7 +80,8 @@ fn jobs_submission_e2e_works_for_dkg() {
 
 		// should fail when caller has no balance
 		let submission = JobSubmission {
-			expiry: 100,
+			expiry: 10,
+			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
 				participants: vec![ALICE, BOB, CHARLIE, DAVE, EVE],
 				threshold: 3,
@@ -92,7 +95,8 @@ fn jobs_submission_e2e_works_for_dkg() {
 		);
 
 		let submission = JobSubmission {
-			expiry: 100,
+			expiry: 10,
+			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
 				participants: vec![ALICE, BOB, CHARLIE, DAVE, EVE],
 				threshold: 3,
@@ -139,7 +143,8 @@ fn jobs_submission_e2e_works_for_dkg() {
 
 		// another account cannot use solution
 		let submission = JobSubmission {
-			expiry: 100,
+			expiry: 10,
+			ttl: 0,
 			job_type: JobType::DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType {
 				phase_one_id: 0,
 				submission: vec![],
@@ -152,7 +157,8 @@ fn jobs_submission_e2e_works_for_dkg() {
 		);
 
 		let submission = JobSubmission {
-			expiry: 100,
+			expiry: 10,
+			ttl: 0,
 			job_type: JobType::DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType {
 				phase_one_id: 0,
 				submission: vec![],

--- a/precompiles/jobs/src/lib.rs
+++ b/precompiles/jobs/src/lib.rs
@@ -66,6 +66,7 @@ where
 	///
 	/// - `handle`: A mutable reference to the `PrecompileHandle` implementation.
 	/// - `expiry`: The expiration period for the submitted job
+	/// - `ttl`: The time-to-live period for the submitted job
 	/// - `participants`: A vector containing Ethereum addresses of the participants in the DKG.
 	/// - `threshold`: The threshold number of participants required for the DKG to succeed (u8).
 	/// - `permitted_caller`: The Ethereum address of the permitted caller.
@@ -73,10 +74,11 @@ where
 	/// # Returns
 	///
 	/// Returns an `EvmResult`, indicating the success or failure of the operation.
-	#[precompile::public("submitDkgPhaseOneJob(uint64,address[],uint8,uint16,address)")]
+	#[precompile::public("submitDkgPhaseOneJob(uint64,unit64,address[],uint8,uint16,address)")]
 	fn submit_dkg_phase_one_job(
 		handle: &mut impl PrecompileHandle,
-		expiry: u64,
+		expiry: BlockNumber,
+		ttl: BlockNumber,
 		participants: Vec<Address>,
 		threshold: u8,
 		role_type: u16,
@@ -121,10 +123,14 @@ where
 
 		// Convert expiration period to Substrate block number
 		let expiry_block: BlockNumberFor<Runtime> = expiry.into();
+		let ttl_block: BlockNumberFor<Runtime> = ttl.into();
 
 		// Create job submission object
-		let job =
-			JobSubmission { expiry: expiry_block, job_type: JobType::DKGTSSPhaseOne(job_type) };
+		let job = JobSubmission {
+			expiry: expiry_block,
+			ttl: ttl_block,
+			job_type: JobType::DKGTSSPhaseOne(job_type),
+		};
 
 		// Convert caller's Ethereum address to Substrate account ID
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -145,6 +151,7 @@ where
 	///
 	/// - `handle`: A mutable reference to the `PrecompileHandle` implementation.
 	/// - `expiry`: The expiration period for the submitted job
+	/// - `ttl`: The time-to-live period for the submitted job
 	/// - `phase_one_id`: The identifier of the corresponding phase one DKG job (u32).
 	/// - `submission`: The signature submission for the DKG phase two, represented as
 	///   `BoundedBytes`.
@@ -152,10 +159,11 @@ where
 	/// # Returns
 	///
 	/// Returns an `EvmResult`, indicating the success or failure of the operation.
-	#[precompile::public("submitDkgPhaseTwoJob(uint64,uint64,bytes)")]
+	#[precompile::public("submitDkgPhaseTwoJob(uint64,uint64,uint64,bytes)")]
 	fn submit_dkg_phase_two_job(
 		handle: &mut impl PrecompileHandle,
 		expiry: BlockNumber,
+		ttl: BlockNumber,
 		phase_one_id: JobId,
 		submission: BoundedBytes<GetJobSubmissionSizeLimit>,
 	) -> EvmResult {
@@ -167,6 +175,7 @@ where
 
 		// Convert expiration period to Substrate block number
 		let expiry_block: BlockNumberFor<Runtime> = expiry.into();
+		let ttl_block: BlockNumberFor<Runtime> = ttl.into();
 
 		// Create DKG signature job type with the provided parameters
 		match pallet_jobs::SubmittedJobsRole::<Runtime>::get(phase_one_id) {
@@ -191,6 +200,7 @@ where
 				// Create job submission object
 				let job = JobSubmission {
 					expiry: expiry_block,
+					ttl: ttl_block,
 					job_type: JobType::DKGTSSPhaseTwo(job_type),
 				};
 

--- a/precompiles/jobs/src/tests.rs
+++ b/precompiles/jobs/src/tests.rs
@@ -30,7 +30,8 @@ fn submit_dkg_phase_one_job() {
 				Precompile1,
 				PCall::submit_dkg_phase_one_job {
 					role_type: RoleType::Tss(ThresholdSignatureRoleType::TssGG20).to_u16(),
-					expiry: 100,
+					expiry: 5,
+					ttl: 200,
 					participants: vec![],
 					threshold: 2,
 					permitted_caller: Address(CryptoAlith.into()),
@@ -49,7 +50,8 @@ fn submit_dkg_phase_two_job() {
 				Address(CryptoAlith.into()),
 				Precompile1,
 				PCall::submit_dkg_phase_two_job {
-					expiry: 100,
+					expiry: 5,
+					ttl: 0,
 					phase_one_id: 1,
 					submission: vec![].into(),
 				},

--- a/primitives/src/jobs/mod.rs
+++ b/primitives/src/jobs/mod.rs
@@ -33,8 +33,13 @@ pub use zksaas::*;
 /// Represents a job submission with specified `AccountId` and `BlockNumber`.
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
 pub struct JobSubmission<AccountId, BlockNumber> {
-	/// The time to live for the submitted job.
+	/// Represents the maximum allowed submission time for a job result.
+	/// Once this time has passed, the result cannot be submitted.
 	pub expiry: BlockNumber,
+
+	/// The time-to-live (TTL) for the job, which determines the maximum allowed time for this job
+	/// to be available. After the TTL expires, the job can no longer be used.
+	pub ttl: BlockNumber,
 
 	/// The type of the job submission.
 	pub job_type: JobType<AccountId>,
@@ -46,8 +51,13 @@ pub struct JobInfo<AccountId, BlockNumber, Balance> {
 	/// The caller that requested the job
 	pub owner: AccountId,
 
-	/// The expiry block number.
+	/// Represents the maximum allowed submission time for a job result.
+	/// Once this time has passed, the result cannot be submitted.
 	pub expiry: BlockNumber,
+
+	/// The time-to-live (TTL) for the job, which determines the maximum allowed time for this job
+	/// to be available. After the TTL expires, the job can no longer be used.
+	pub ttl: BlockNumber,
 
 	/// The type of the job submission.
 	pub job_type: JobType<AccountId>,
@@ -187,10 +197,11 @@ pub enum JobState {
 pub struct PhaseResult<AccountId, BlockNumber> {
 	/// The owner's account ID.
 	pub owner: AccountId,
-	/// The time to live as a block number.
-	pub expiry: BlockNumber,
 	/// The type of the job submission.
-	pub result: Vec<u8>,
+	pub result: JobResult,
+	/// The time-to-live (TTL) for the job, which determines the maximum allowed time for this job
+	/// to be available. After the TTL expires, the job can no longer be used.
+	pub ttl: BlockNumber,
 	/// permitted caller to use this result
 	pub permitted_caller: Option<AccountId>,
 	/// The type of the job submission.
@@ -229,32 +240,35 @@ pub enum ValidatorOffence {
 
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct RpcResponseJobsData<AccountId> {
+pub struct RpcResponseJobsData<AccountId, BlockNumber> {
 	/// The job id of the job
 	pub job_id: JobId,
 
 	/// The type of the job submission.
 	pub job_type: JobType<AccountId>,
 
-	/// (Optional) List of participants' account IDs.
-	pub participants: Option<Vec<AccountId>>,
+	/// Represents the maximum allowed submission time for a job result.
+	/// Once this time has passed, the result cannot be submitted.
+	pub expiry: BlockNumber,
 
-	/// threshold if any for the original set
-	pub threshold: Option<u8>,
-
-	/// previous phase key if any
-	pub key: Option<Vec<u8>>,
+	/// The time-to-live (TTL) for the job, which determines the maximum allowed time for this job
+	/// to be available. After the TTL expires, the job can no longer be used.
+	pub ttl: BlockNumber,
 }
 
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct RpcResponsePhaseOneResult<AccountId> {
+pub struct RpcResponsePhaseOneResult<AccountId, BlockNumber> {
 	/// The owner's account ID.
 	pub owner: AccountId,
 	/// The type of the job result.
-	pub result: Vec<u8>,
+	pub result: JobResult,
 	/// The type of the job submission.
 	pub job_type: JobType<AccountId>,
+
+	/// The time-to-live (TTL) for the job, which determines the maximum allowed time for this job
+	/// to be available. After the TTL expires, the job can no longer be used.
+	pub ttl: BlockNumber,
 }
 
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1344,6 +1344,7 @@ mod benches {
 	);
 }
 
+use pallet_jobs_rpc_runtime_api::BlockNumberOf;
 impl_runtime_apis! {
 	impl sp_api::Core<Block> for Runtime {
 		fn version() -> RuntimeVersion {
@@ -1397,15 +1398,15 @@ impl_runtime_apis! {
 	impl pallet_jobs_rpc_runtime_api::JobsApi<Block, AccountId> for Runtime {
 		fn query_jobs_by_validator(
 			validator: AccountId,
-		) -> Option<Vec<RpcResponseJobsData<AccountId>>> {
+		) -> Option<Vec<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>>> {
 			Jobs::query_jobs_by_validator(validator)
 		}
 
-		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId>> {
+		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>> {
 			Jobs::query_job_by_id(role_type, job_id)
 		}
 
-		fn query_phase_one_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponsePhaseOneResult<AccountId>> {
+		fn query_phase_one_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponsePhaseOneResult<AccountId, BlockNumberOf<Block>>> {
 			Jobs::query_phase_one_by_id(role_type, job_id)
 		}
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Introduce `ttl` for Jobs
- Job `expiry` Represents the maximum allowed submission time for a job result. After which, the result cannot be submitted.
- Job `ttl` The time-to-live (TTL) for the job, which determines the maximum allowed time for this job to be available. After the TTL expires, the job can no longer be used.
- Add checks on when a PhaseTwo uses and expired PhaseOne Result.
- Emit events whenever a job expires or ended.

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #381 
Closes #382
