### PR TITLE
bugfix: zkSaaS Phase2 submitted jobs not found

### DIFF
--- a/pallets/jobs/src/functions.rs
+++ b/pallets/jobs/src/functions.rs
@@ -450,14 +450,9 @@ impl<T: Config> Pallet<T> {
 
 		let job_result = JobResult::ZkSaaSPhaseTwo(info.clone());
 
-		let phase_one_job_info = SubmittedJobs::<T>::get(
-			role_type,
-			job_info.job_type.get_phase_one_id().ok_or(Error::<T>::InvalidJobPhase)?,
-		)
-		.ok_or(Error::<T>::JobNotFound)?;
 		T::MPCHandler::verify(JobWithResult {
 			job_type: job_info.job_type.clone(),
-			phase_one_job_type: Some(phase_one_job_info.job_type),
+			phase_one_job_type: Some(phase_one_result.job_type),
 			result: job_result.clone(),
 		})?;
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Fixes the issue when we attempt to obtain phase one job data from the submitted jobs inside phase 2, which would initially fail since phase one is no longer present in the submitted jobs at this point and is only found in known outcomes.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
