### PR TITLE
fix: use ubuntu20 to build release image

### DIFF
--- a/.github/workflows/publish-release-binary.yml
+++ b/.github/workflows/publish-release-binary.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Publish binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Use older ubuntu version (v20) to build the release image, this will avoid the following errors on older systems
```
./tangle-testnet-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./tangle-testnet-linux-amd64)
./tangle-testnet-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./tangle-testnet-linux-amd64)
./tangle-testnet-linux-amd64: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./tangle-testnet-linux-amd64)
```

For systems with older than ubuntu20, will have to build from source since github runners does not support those.