### PR TITLE
Update and allow switching independent to shared profile

### DIFF
--- a/pallets/jobs/src/benchmarking.rs
+++ b/pallets/jobs/src/benchmarking.rs
@@ -22,7 +22,7 @@ benchmarks! {
 		let job =  JobSubmissionOf::<T> {
 			expiry: 100u32.into(),
 			ttl: 100u32.into(),
-			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), caller.clone()], threshold: 1, permitted_caller: None, role_type : ThresholdSignatureRoleType::TssGG20  }),
+			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), caller.clone()], threshold: 1, permitted_caller: None, role_type : Default::default()  }),
 		};
 
 	}: _(RawOrigin::Signed(caller.clone()), job.clone())
@@ -35,10 +35,10 @@ benchmarks! {
 		let job =  JobSubmissionOf::<T> {
 			expiry: 100u32.into(),
 			ttl: 100u32.into(),
-			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), validator2], threshold: 1, permitted_caller: None, role_type : ThresholdSignatureRoleType::TssGG20 }),
+			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), validator2], threshold: 1, permitted_caller: None, role_type : Default::default() }),
 		};
 		let _ = Pallet::<T>::submit_job(RawOrigin::Signed(caller.clone()).into(), job);
-		let job_key: RoleType = RoleType::Tss(ThresholdSignatureRoleType::TssGG20);
+		let job_key: RoleType = RoleType::Tss(Default::default());
 		let job_id: JobId = 0;
 		let result = JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
 			signatures: vec![],
@@ -66,10 +66,11 @@ benchmarks! {
 		let _ = T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		let job =  JobSubmissionOf::<T> {
 			expiry: 100u32.into(),
-			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), validator2, validator3], threshold: 2, permitted_caller: None, role_type : ThresholdSignatureRoleType::TssGG20 }),
-			};
+			ttl: 100u32.into(),
+			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), validator2, validator3], threshold: 2, permitted_caller: None, role_type : Default::default() }),
+		};
 		let _ = Pallet::<T>::submit_job(RawOrigin::Signed(caller.clone()).into(), job);
-		let job_key: RoleType = RoleType::Tss(ThresholdSignatureRoleType::TssGG20);
+		let job_key: RoleType = RoleType::Tss(Default::default());
 		let job_id: JobId = 0;
 	}: _(RawOrigin::Signed(caller.clone()), job_key.clone(), job_id.clone(), caller.clone(), ValidatorOffenceType::Inactivity, vec![])
 }

--- a/pallets/jobs/src/benchmarking.rs
+++ b/pallets/jobs/src/benchmarking.rs
@@ -21,6 +21,7 @@ benchmarks! {
 		let _ = T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		let job =  JobSubmissionOf::<T> {
 			expiry: 100u32.into(),
+			ttl: 100u32.into(),
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), caller.clone()], threshold: 1, permitted_caller: None, role_type : ThresholdSignatureRoleType::TssGG20  }),
 		};
 
@@ -33,6 +34,7 @@ benchmarks! {
 		let _ = T::Currency::make_free_balance_be(&caller, BalanceOf::<T>::max_value());
 		let job =  JobSubmissionOf::<T> {
 			expiry: 100u32.into(),
+			ttl: 100u32.into(),
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType { participants: vec![caller.clone(), validator2], threshold: 1, permitted_caller: None, role_type : ThresholdSignatureRoleType::TssGG20 }),
 		};
 		let _ = Pallet::<T>::submit_job(RawOrigin::Signed(caller.clone()).into(), job);

--- a/pallets/roles/src/benchmarking.rs
+++ b/pallets/roles/src/benchmarking.rs
@@ -26,7 +26,7 @@ use frame_support::BoundedVec;
 use frame_system::RawOrigin;
 use sp_core::sr25519;
 use sp_runtime::Perbill;
-use tangle_primitives::roles::RoleTypeMetadata;
+use tangle_primitives::roles::RoleType;
 
 fn assert_last_event<T: Config>(generic_event: <T as Config>::RuntimeEvent) {
 	frame_system::Pallet::<T>::assert_last_event(generic_event.into());
@@ -36,8 +36,8 @@ pub fn shared_profile<T: Config>() -> Profile<T> {
 	let amount: T::CurrencyBalance = 3000_u64.into();
 	let profile = SharedRestakeProfile {
 		records: BoundedVec::try_from(vec![
-			Record { metadata: RoleTypeMetadata::Tss(Default::default()), amount: None },
-			Record { metadata: RoleTypeMetadata::ZkSaas(Default::default()), amount: None },
+			Record { role: RoleType::Tss(Default::default()), amount: None },
+			Record { role: RoleType::ZkSaaS(Default::default()), amount: None },
 		])
 		.unwrap(),
 		amount,
@@ -49,8 +49,8 @@ pub fn updated_profile<T: Config>() -> Profile<T> {
 	let amount: T::CurrencyBalance = 5000_u64.into();
 	let profile = SharedRestakeProfile {
 		records: BoundedVec::try_from(vec![
-			Record { metadata: RoleTypeMetadata::Tss(Default::default()), amount: None },
-			Record { metadata: RoleTypeMetadata::ZkSaas(Default::default()), amount: None },
+			Record { role: RoleType::Tss(Default::default()), amount: None },
+			Record { role: RoleType::ZkSaaS(Default::default()), amount: None },
 		])
 		.unwrap(),
 		amount,
@@ -112,7 +112,7 @@ mod benchmarks {
 	fn update_profile() {
 		let caller: T::AccountId = create_validator_account::<T>("Alice");
 		let shared_profile = shared_profile::<T>();
-		let ledger = RoleStakingLedger::<T>::new(caller.clone(), shared_profile.clone());
+		let ledger = RoleStakingLedger::<T>::new(caller.clone(), shared_profile.clone(), vec![]);
 		Ledger::<T>::insert(caller.clone(), ledger);
 		// Updating shared stake from 3000 to 5000 tokens
 		let updated_profile = updated_profile::<T>();
@@ -129,7 +129,7 @@ mod benchmarks {
 	fn delete_profile() {
 		let caller: T::AccountId = create_validator_account::<T>("Alice");
 		let shared_profile = shared_profile::<T>();
-		let ledger = RoleStakingLedger::<T>::new(caller.clone(), shared_profile.clone());
+		let ledger = RoleStakingLedger::<T>::new(caller.clone(), shared_profile.clone(), vec![]);
 		Ledger::<T>::insert(caller.clone(), ledger);
 
 		#[extrinsic_call]

--- a/shared
+++ b/shared
@@ -1,0 +1,3 @@
+[drew/update-role-validation 12c1825] Update and allow switching independent - profile
+ 2 files changed, 29 insertions(+), 16 deletions(-)
+ create mode 100644 shared


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Ind. to shared profile switching allowed as long as sum of active role restakes is preserved in shared total restake.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
