### PR TITLE
fix: make all types bounded

### DIFF
--- a/pallets/dkg/src/lib.rs
+++ b/pallets/dkg/src/lib.rs
@@ -46,6 +46,7 @@ pub mod pallet {
 		traits::{Get, ReservableCurrency},
 	};
 	use frame_system::pallet_prelude::*;
+	use scale_info::prelude::fmt::Debug;
 	use sp_std::prelude::*;
 	use tangle_primitives::jobs::JobId;
 
@@ -60,6 +61,24 @@ pub mod pallet {
 
 		/// The origin which may set filter.
 		type UpdateOrigin: EnsureOrigin<Self::RuntimeOrigin>;
+
+		/// The maximum participants allowed in a job
+		type MaxParticipants: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of job result submission
+		type MaxSubmissionLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of a signature
+		type MaxSignatureLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of data to be signed
+		type MaxDataLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of validator key allowed
+		type MaxKeyLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of proof allowed
+		type MaxProofLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
 
 		/// Weight info for pallet
 		type WeightInfo: WeightInfo;

--- a/pallets/dkg/src/mock.rs
+++ b/pallets/dkg/src/mock.rs
@@ -18,10 +18,11 @@
 use super::*;
 use crate as pallet_dkg;
 use frame_support::{
-	construct_runtime,
+	construct_runtime, parameter_types,
 	traits::{ConstU128, ConstU32, ConstU64, Everything},
 };
 use frame_system::EnsureSigned;
+use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_keystore::{testing::MemoryKeystore, KeystoreExt, KeystorePtr};
 use sp_runtime::{testing::Header, traits::IdentityLookup, BuildStorage};
@@ -76,10 +77,31 @@ frame_support::ord_parameter_types! {
 	pub const One: AccountId = 1;
 }
 
+parameter_types! {
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxParticipants: u32 = 10;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSubmissionLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxKeyLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxDataLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSignatureLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxProofLen: u32 = 256;
+}
+
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type UpdateOrigin = EnsureSigned<AccountId>;
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
 	type WeightInfo = ();
 }
 

--- a/pallets/dkg/src/tests.rs
+++ b/pallets/dkg/src/tests.rs
@@ -71,9 +71,9 @@ fn dkg_key_verifcation_works_for_ecdsa() {
 	new_test_ext().execute_with(|| {
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			key: vec![],
-			participants: vec![],
-			signatures: vec![],
+			key: vec![].try_into().unwrap(),
+			participants: vec![].try_into().unwrap(),
+			signatures: vec![].try_into().unwrap(),
 			threshold: 2,
 		};
 
@@ -85,9 +85,11 @@ fn dkg_key_verifcation_works_for_ecdsa() {
 
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			key: vec![],
-			participants: vec![mock_pub_key_ecdsa().as_mut().to_vec()],
-			signatures: vec![],
+			key: vec![].try_into().unwrap(),
+			participants: vec![mock_pub_key_ecdsa().as_mut().to_vec().try_into().unwrap()]
+				.try_into()
+				.unwrap(),
+			signatures: vec![].try_into().unwrap(),
 			threshold: 2,
 		};
 
@@ -103,9 +105,11 @@ fn dkg_key_verifcation_works_for_ecdsa() {
 
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			key: vec![],
-			participants: vec![mock_pub_key_ecdsa().as_mut().to_vec()],
-			signatures: vec![signature.clone()],
+			key: vec![].try_into().unwrap(),
+			participants: vec![mock_pub_key_ecdsa().as_mut().to_vec().try_into().unwrap()]
+				.try_into()
+				.unwrap(),
+			signatures: vec![signature.clone().try_into().unwrap()].try_into().unwrap(),
 			threshold: 1,
 		};
 
@@ -117,9 +121,14 @@ fn dkg_key_verifcation_works_for_ecdsa() {
 
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			key: pub_key.0.to_vec(),
-			participants: vec![pub_key.as_mut().to_vec()],
-			signatures: vec![signature.clone(), signature.clone()],
+			key: pub_key.0.to_vec().try_into().unwrap(),
+			participants: vec![pub_key.as_mut().to_vec().try_into().unwrap()].try_into().unwrap(),
+			signatures: vec![
+				signature.clone().try_into().unwrap(),
+				signature.clone().try_into().unwrap(),
+			]
+			.try_into()
+			.unwrap(),
 			threshold: 1,
 		};
 
@@ -136,12 +145,16 @@ fn dkg_key_verifcation_works_for_ecdsa() {
 		let signature_two = mock_signature_ecdsa(participant_two, participant_one);
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			key: participant_one.to_raw_vec(),
+			key: participant_one.to_raw_vec().try_into().unwrap(),
 			participants: vec![
-				participant_one.as_mut().to_vec(),
-				participant_two.as_mut().to_vec(),
-			],
-			signatures: vec![signature_two, signature_one],
+				participant_one.as_mut().to_vec().try_into().unwrap(),
+				participant_two.as_mut().to_vec().try_into().unwrap(),
+			]
+			.try_into()
+			.unwrap(),
+			signatures: vec![signature_two.try_into().unwrap(), signature_one.try_into().unwrap()]
+				.try_into()
+				.unwrap(),
 			threshold: 1,
 		};
 
@@ -155,9 +168,9 @@ fn dkg_key_verifcation_works_for_schnorr() {
 	new_test_ext().execute_with(|| {
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			key: mock_pub_key_sr25519().to_vec(),
-			participants: vec![],
-			signatures: vec![],
+			key: mock_pub_key_sr25519().to_vec().try_into().unwrap(),
+			participants: vec![].try_into().unwrap(),
+			signatures: vec![].try_into().unwrap(),
 			threshold: 2,
 		};
 
@@ -169,9 +182,11 @@ fn dkg_key_verifcation_works_for_schnorr() {
 
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			key: vec![],
-			participants: vec![mock_pub_key_sr25519().as_mut().to_vec()],
-			signatures: vec![],
+			key: vec![].try_into().unwrap(),
+			participants: vec![mock_pub_key_sr25519().as_mut().to_vec().try_into().unwrap()]
+				.try_into()
+				.unwrap(),
+			signatures: vec![].try_into().unwrap(),
 			threshold: 2,
 		};
 
@@ -187,9 +202,11 @@ fn dkg_key_verifcation_works_for_schnorr() {
 
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			key: pub_key.to_vec(),
-			participants: vec![mock_pub_key_sr25519().as_mut().to_vec()],
-			signatures: vec![signature.clone()],
+			key: pub_key.to_vec().try_into().unwrap(),
+			participants: vec![mock_pub_key_sr25519().as_mut().to_vec().try_into().unwrap()]
+				.try_into()
+				.unwrap(),
+			signatures: vec![signature.clone().try_into().unwrap()].try_into().unwrap(),
 			threshold: 1,
 		};
 
@@ -201,9 +218,14 @@ fn dkg_key_verifcation_works_for_schnorr() {
 
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			key: pub_key.to_vec(),
-			participants: vec![pub_key.as_mut().to_vec()],
-			signatures: vec![signature.clone(), signature.clone()],
+			key: pub_key.to_vec().try_into().unwrap(),
+			participants: vec![pub_key.as_mut().to_vec().try_into().unwrap()].try_into().unwrap(),
+			signatures: vec![
+				signature.clone().try_into().unwrap(),
+				signature.clone().try_into().unwrap(),
+			]
+			.try_into()
+			.unwrap(),
 			threshold: 1,
 		};
 
@@ -220,12 +242,16 @@ fn dkg_key_verifcation_works_for_schnorr() {
 		let signature_two = mock_signature_sr25519(participant_two, participant_one);
 		let job_to_verify = DKGTSSKeySubmissionResult {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			key: participant_one.to_raw_vec(),
+			key: participant_one.to_raw_vec().try_into().unwrap(),
 			participants: vec![
-				participant_one.as_mut().to_vec(),
-				participant_two.as_mut().to_vec(),
-			],
-			signatures: vec![signature_two, signature_one],
+				participant_one.as_mut().to_vec().try_into().unwrap(),
+				participant_two.as_mut().to_vec().try_into().unwrap(),
+			]
+			.try_into()
+			.unwrap(),
+			signatures: vec![signature_two.try_into().unwrap(), signature_one.try_into().unwrap()]
+				.try_into()
+				.unwrap(),
 			threshold: 1,
 		};
 
@@ -241,11 +267,11 @@ fn dkg_signature_verifcation_works_ecdsa() {
 		let pub_key = mock_pub_key_ecdsa();
 		let signature = mock_signature_ecdsa(pub_key, mock_pub_key_ecdsa());
 
-		let job_to_verify: DKGTSSSignatureResult = DKGTSSSignatureResult {
+		let job_to_verify = DKGTSSSignatureResult::<MaxDataLen, MaxKeyLen, MaxSignatureLen> {
 			signature_type: DigitalSignatureType::Ecdsa,
-			signature,
-			data: pub_key.to_raw_vec(),
-			signing_key: pub_key.to_raw_vec(),
+			signature: signature.try_into().unwrap(),
+			data: pub_key.to_raw_vec().try_into().unwrap(),
+			signing_key: pub_key.to_raw_vec().try_into().unwrap(),
 		};
 
 		// should fail for invalid keys
@@ -255,11 +281,11 @@ fn dkg_signature_verifcation_works_ecdsa() {
 		);
 
 		let signature = mock_signature_ecdsa(pub_key, pub_key);
-		let job_to_verify: DKGTSSSignatureResult = DKGTSSSignatureResult {
+		let job_to_verify = DKGTSSSignatureResult::<MaxDataLen, MaxKeyLen, MaxSignatureLen> {
 			signature_type: DigitalSignatureType::Ecdsa,
-			signature,
-			data: pub_key.to_raw_vec(),
-			signing_key: pub_key.to_raw_vec(),
+			signature: signature.try_into().unwrap(),
+			data: pub_key.to_raw_vec().try_into().unwrap(),
+			signing_key: pub_key.to_raw_vec().try_into().unwrap(),
 		};
 
 		// should work with correct params
@@ -274,11 +300,11 @@ fn dkg_signature_verifcation_works_schnorr() {
 		let pub_key = mock_pub_key_sr25519();
 		let signature = mock_signature_sr25519(pub_key, mock_pub_key_sr25519());
 
-		let job_to_verify: DKGTSSSignatureResult = DKGTSSSignatureResult {
+		let job_to_verify = DKGTSSSignatureResult::<MaxDataLen, MaxKeyLen, MaxSignatureLen> {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			signature,
-			data: pub_key.to_raw_vec(),
-			signing_key: pub_key.to_raw_vec(),
+			signature: signature.try_into().unwrap(),
+			data: pub_key.to_raw_vec().try_into().unwrap(),
+			signing_key: pub_key.to_raw_vec().try_into().unwrap(),
 		};
 
 		// should fail for invalid keys
@@ -288,11 +314,11 @@ fn dkg_signature_verifcation_works_schnorr() {
 		);
 
 		let signature = mock_signature_sr25519(pub_key, pub_key);
-		let job_to_verify: DKGTSSSignatureResult = DKGTSSSignatureResult {
+		let job_to_verify = DKGTSSSignatureResult {
 			signature_type: DigitalSignatureType::SchnorrSr25519,
-			signature,
-			data: pub_key.to_raw_vec(),
-			signing_key: pub_key.to_raw_vec(),
+			signature: signature.try_into().unwrap(),
+			data: pub_key.to_raw_vec().try_into().unwrap(),
+			signing_key: pub_key.to_raw_vec().try_into().unwrap(),
 		};
 
 		// should work with correct params
@@ -311,9 +337,9 @@ fn dkg_key_rotation_works() {
 
 		let job_to_verify = DKGTSSKeyRotationResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			signature,
-			key: curr_key.to_raw_vec(),
-			new_key: new_key.to_raw_vec(),
+			signature: signature.try_into().unwrap(),
+			key: curr_key.to_raw_vec().try_into().unwrap(),
+			new_key: new_key.to_raw_vec().try_into().unwrap(),
 			phase_one_id: 1,
 			new_phase_one_id: 2,
 		};
@@ -328,9 +354,9 @@ fn dkg_key_rotation_works() {
 
 		let job_to_verify = DKGTSSKeyRotationResult {
 			signature_type: DigitalSignatureType::Ecdsa,
-			signature: signature.clone(),
-			key: curr_key.to_raw_vec(),
-			new_key: new_key.to_raw_vec(),
+			signature: signature.clone().try_into().unwrap(),
+			key: curr_key.to_raw_vec().try_into().unwrap(),
+			new_key: new_key.to_raw_vec().try_into().unwrap(),
 			phase_one_id: 1,
 			new_phase_one_id: 2,
 		};

--- a/pallets/jobs/rpc/runtime-api/src/lib.rs
+++ b/pallets/jobs/rpc/runtime-api/src/lib.rs
@@ -16,9 +16,12 @@
 //! Runtime API definition for jobs pallet.
 
 #![cfg_attr(not(feature = "std"), no_std)]
-
+#![allow(clippy::type_complexity)]
 use parity_scale_codec::Codec;
-use sp_runtime::{traits::MaybeDisplay, Serialize};
+use sp_runtime::{
+	traits::{Get, MaybeDisplay},
+	Serialize,
+};
 use sp_std::vec::Vec;
 use tangle_primitives::{
 	jobs::{JobId, PhaseResult, RpcResponseJobsData},
@@ -29,8 +32,14 @@ pub type BlockNumberOf<Block> =
 	<<Block as sp_runtime::traits::HeaderProvider>::HeaderT as sp_runtime::traits::Header>::Number;
 
 sp_api::decl_runtime_apis! {
-	pub trait JobsApi<AccountId> where
+	pub trait JobsApi<AccountId, MaxParticipants, MaxSubmissionLen, MaxKeyLen, MaxDataLen, MaxSignatureLen, MaxProofLen> where
 		AccountId: Codec + MaybeDisplay + Serialize,
+		MaxParticipants: Codec + Serialize + Get<u32> + Clone,
+		MaxSubmissionLen: Codec + Serialize + Get<u32>,
+		MaxKeyLen: Codec + Serialize + Get<u32>,
+		MaxDataLen: Codec + Serialize + Get<u32>,
+		MaxSignatureLen: Codec + Serialize + Get<u32>,
+		MaxProofLen: Codec + Serialize + Get<u32>,
 	{
 		/// Query jobs associated with a specific validator.
 		///
@@ -46,7 +55,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		///
 		/// An optional vec of `RpcResponseJobsData` of jobs assigned to validator
-		fn query_jobs_by_validator(validator: AccountId) -> Option<Vec<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>>>;
+		fn query_jobs_by_validator(validator: AccountId) -> Option<Vec<RpcResponseJobsData<AccountId, BlockNumberOf<Block>, MaxParticipants, MaxSubmissionLen>>>;
 		/// Queries a job by its key and ID.
 		///
 		/// # Arguments
@@ -57,7 +66,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		///
 		/// An optional `RpcResponseJobsData` containing the account ID of the job.
-		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>>;
+		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId, BlockNumberOf<Block>, MaxParticipants, MaxSubmissionLen>>;
 
 		/// Queries the result of a job by its role_type and ID.
 		///
@@ -69,7 +78,7 @@ sp_api::decl_runtime_apis! {
 		/// # Returns
 		///
 		/// An `Option` containing the phase one result of the job, wrapped in an `PhaseResult`.
-		fn query_job_result(role_type: RoleType, job_id: JobId) -> Option<PhaseResult<AccountId, BlockNumberOf<Block>>>;
+		fn query_job_result(role_type: RoleType, job_id: JobId) -> Option<PhaseResult<AccountId, BlockNumberOf<Block>, MaxParticipants, MaxKeyLen, MaxDataLen, MaxSignatureLen, MaxSubmissionLen, MaxProofLen>>;
 
 		/// Queries next job ID.
 		///

--- a/pallets/jobs/src/functions.rs
+++ b/pallets/jobs/src/functions.rs
@@ -1,10 +1,13 @@
 use super::*;
+use crate::types::{
+	DKGTSSKeyRotationResultOf, DKGTSSKeySubmissionResultOf, DKGTSSSignatureResultOf,
+	ParticipantKeyOf, ParticipantKeysOf, ZkSaaSCircuitResultOf, ZkSaaSProofResultOf,
+};
 use sp_runtime::traits::Zero;
 use tangle_primitives::{
 	jobs::{
-		DKGTSSKeyRefreshResult, DKGTSSKeyRotationResult, DKGTSSPhaseOneJobType,
-		DKGTSSSignatureResult, JobType, JobWithResult, ZkSaaSCircuitResult, ZkSaaSPhaseOneJobType,
-		ZkSaaSProofResult,
+		DKGTSSKeyRefreshResult, DKGTSSPhaseOneJobType, JobType, JobWithResult,
+		ZkSaaSPhaseOneJobType,
 	},
 	roles::RoleType,
 };
@@ -30,7 +33,8 @@ impl<T: Config> Pallet<T> {
 	) -> DispatchResult {
 		ValidatorJobIdLookup::<T>::try_mutate(validator, |jobs| -> DispatchResult {
 			let jobs = jobs.get_or_insert_with(Default::default);
-			jobs.push((role_type, job_id));
+			jobs.try_push((role_type, job_id))
+				.map_err(|_| Error::<T>::TooManyJobsForValidator)?;
 			Ok(())
 		})
 	}
@@ -164,7 +168,10 @@ impl<T: Config> Pallet<T> {
 							.ok_or(Error::<T>::InvalidJobPhase)?
 							.into_iter()
 							.filter(|x| x != &validator)
-							.collect();
+							.collect::<Vec<_>>()
+							.try_into()
+							.map_err(|_| Error::<T>::TooManyParticipants)?;
+
 						let new_threshold = phase1
 							.threshold()
 							.ok_or(Error::<T>::InvalidJobPhase)?
@@ -214,7 +221,9 @@ impl<T: Config> Pallet<T> {
 							.ok_or(Error::<T>::InvalidJobPhase)?
 							.into_iter()
 							.filter(|x| x != &validator)
-							.collect();
+							.collect::<Vec<_>>()
+							.try_into()
+							.map_err(|_| Error::<T>::TooManyParticipants)?;
 						let phase_one_id = job_info
 							.job_type
 							.get_phase_one_id()
@@ -272,7 +281,7 @@ impl<T: Config> Pallet<T> {
 	pub fn verify_dkg_job_result(
 		role_type: RoleType,
 		job_info: &JobInfoOf<T>,
-		info: DKGTSSKeySubmissionResult,
+		info: DKGTSSKeySubmissionResultOf<T>,
 	) -> Result<PhaseResultOf<T>, DispatchError> {
 		// sanity check, does job and result type match
 		ensure!(role_type.is_dkg_tss(), Error::<T>::ResultNotExpectedType);
@@ -283,15 +292,21 @@ impl<T: Config> Pallet<T> {
 			.clone()
 			.get_participants()
 			.ok_or(Error::<T>::InvalidJobParams)?;
-		let mut participant_keys: Vec<Vec<u8>> = Default::default();
+		let mut participant_keys: ParticipantKeysOf<T> = Default::default();
 
 		for participant in participants.clone() {
 			let key = T::RolesHandler::get_validator_role_key(participant);
 			ensure!(key.is_some(), Error::<T>::ValidatorRoleKeyNotFound);
-			participant_keys.push(key.expect("checked above"));
+			let bounded_key: ParticipantKeyOf<T> = key
+				.expect("Checked above!")
+				.try_into()
+				.map_err(|_| Error::<T>::ExceedsMaxKeySize)?;
+			participant_keys
+				.try_push(bounded_key)
+				.map_err(|_| Error::<T>::TooManyParticipants)?;
 		}
 
-		let job_result = JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
+		let job_result = JobResult::DKGPhaseOne(DKGTSSKeySubmissionResultOf::<T> {
 			key: info.key.clone(),
 			signatures: info.signatures,
 			participants: participant_keys,
@@ -318,7 +333,7 @@ impl<T: Config> Pallet<T> {
 	pub fn verify_dkg_signature_job_result(
 		role_type: RoleType,
 		job_info: &JobInfoOf<T>,
-		info: DKGTSSSignatureResult,
+		info: DKGTSSSignatureResultOf<T>,
 	) -> Result<PhaseResultOf<T>, DispatchError> {
 		let now = <frame_system::Pallet<T>>::block_number();
 		// sanity check, does job and result type match
@@ -352,7 +367,7 @@ impl<T: Config> Pallet<T> {
 			JobResult::DKGPhaseOne(result) => result.key,
 			_ => return Err(Error::<T>::InvalidJobPhase.into()),
 		};
-		let job_result = JobResult::DKGPhaseTwo(DKGTSSSignatureResult {
+		let job_result = JobResult::DKGPhaseTwo(DKGTSSSignatureResultOf::<T> {
 			signature: info.signature.clone(),
 			data: info.data,
 			signing_key,
@@ -442,7 +457,7 @@ impl<T: Config> Pallet<T> {
 	pub fn verify_dkg_key_rotation_job_result(
 		role_type: RoleType,
 		job_info: &JobInfoOf<T>,
-		info: DKGTSSKeyRotationResult,
+		info: DKGTSSKeyRotationResultOf<T>,
 	) -> Result<PhaseResultOf<T>, DispatchError> {
 		let now = <frame_system::Pallet<T>>::block_number();
 		// sanity check, does job and result type match
@@ -491,7 +506,7 @@ impl<T: Config> Pallet<T> {
 			JobResult::DKGPhaseOne(info) => info.key.clone(),
 			_ => return Err(Error::<T>::InvalidJobPhase.into()),
 		};
-		let job_result = JobResult::DKGPhaseFour(DKGTSSKeyRotationResult {
+		let job_result = JobResult::DKGPhaseFour(DKGTSSKeyRotationResultOf::<T> {
 			phase_one_id: job_info
 				.job_type
 				.get_phase_one_id()
@@ -523,7 +538,7 @@ impl<T: Config> Pallet<T> {
 		role_type: RoleType,
 		job_id: JobId,
 		job_info: &JobInfoOf<T>,
-		_info: ZkSaaSCircuitResult,
+		_info: ZkSaaSCircuitResultOf<T>,
 	) -> Result<PhaseResultOf<T>, DispatchError> {
 		// sanity check, does job and result type match
 		ensure!(role_type.is_zksaas(), Error::<T>::ResultNotExpectedType);
@@ -534,17 +549,22 @@ impl<T: Config> Pallet<T> {
 			.clone()
 			.get_participants()
 			.ok_or(Error::<T>::InvalidJobParams)?;
-		let mut participant_keys: Vec<sp_core::ecdsa::Public> = Default::default();
+		let mut participant_keys: BoundedVec<
+			sp_core::ecdsa::Public,
+			<T as Config>::MaxParticipants,
+		> = Default::default();
 
 		for participant in participants.clone() {
 			let key = T::RolesHandler::get_validator_role_key(participant);
 			ensure!(key.is_some(), Error::<T>::ValidatorRoleKeyNotFound);
 			let pub_key = sp_core::ecdsa::Public::from_slice(&key.expect("checked above")[0..33])
 				.map_err(|_| Error::<T>::InvalidValidator)?;
-			participant_keys.push(pub_key);
+			participant_keys
+				.try_push(pub_key)
+				.map_err(|_| Error::<T>::TooManyParticipants)?;
 		}
 
-		let job_result = JobResult::ZkSaaSPhaseOne(ZkSaaSCircuitResult {
+		let job_result = JobResult::ZkSaaSPhaseOne(ZkSaaSCircuitResultOf::<T> {
 			job_id,
 			participants: participant_keys,
 		});
@@ -568,7 +588,7 @@ impl<T: Config> Pallet<T> {
 	pub fn verify_zksaas_prove_job_result(
 		role_type: RoleType,
 		job_info: &JobInfoOf<T>,
-		info: ZkSaaSProofResult,
+		info: ZkSaaSProofResultOf<T>,
 	) -> Result<PhaseResultOf<T>, DispatchError> {
 		let now = <frame_system::Pallet<T>>::block_number();
 		// sanity check, does job and result type match

--- a/pallets/jobs/src/impls.rs
+++ b/pallets/jobs/src/impls.rs
@@ -14,7 +14,7 @@ impl<T: Config> JobsHandler<T::AccountId> for Pallet<T> {
 	/// Returns a vector of `JobId` representing the active jobs of the validator.
 	fn get_active_jobs(validator: T::AccountId) -> Vec<(RoleType, JobId)> {
 		if let Some(jobs) = ValidatorJobIdLookup::<T>::get(validator) {
-			return jobs
+			return jobs.to_vec()
 		}
 		Default::default()
 	}

--- a/pallets/jobs/src/mock.rs
+++ b/pallets/jobs/src/mock.rs
@@ -91,7 +91,9 @@ impl pallet_balances::Config for Runtime {
 
 pub struct MockDKGPallet;
 impl MockDKGPallet {
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		if job.job_type.is_phase_one() {
 			job.job_type.clone().get_participants().unwrap().len().try_into().unwrap()
 		} else {
@@ -102,7 +104,9 @@ impl MockDKGPallet {
 
 pub struct MockZkSaasPallet;
 impl MockZkSaasPallet {
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		if job.job_type.is_phase_one() {
 			10
 		} else {
@@ -113,10 +117,12 @@ impl MockZkSaasPallet {
 
 pub struct MockJobToFeeHandler;
 
-impl JobToFee<AccountId, BlockNumber> for MockJobToFeeHandler {
+impl JobToFee<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen> for MockJobToFeeHandler {
 	type Balance = Balance;
 
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		match job.job_type {
 			JobType::DKGTSSPhaseOne(_) |
 			JobType::DKGTSSPhaseTwo(_) |
@@ -130,8 +136,30 @@ impl JobToFee<AccountId, BlockNumber> for MockJobToFeeHandler {
 
 pub struct MockMPCHandler;
 
-impl MPCHandler<AccountId, BlockNumber, Balance> for MockMPCHandler {
-	fn verify(_data: JobWithResult<AccountId>) -> DispatchResult {
+impl
+	MPCHandler<
+		AccountId,
+		BlockNumber,
+		Balance,
+		MaxParticipants,
+		MaxSubmissionLen,
+		MaxKeyLen,
+		MaxDataLen,
+		MaxSignatureLen,
+		MaxProofLen,
+	> for MockMPCHandler
+{
+	fn verify(
+		_data: JobWithResult<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		>,
+	) -> DispatchResult {
 		Ok(())
 	}
 
@@ -294,17 +322,32 @@ impl pallet_roles::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type JobsHandler = Jobs;
 	type MaxRolesPerAccount = ConstU32<2>;
-	type MPCHandler = MockMPCHandler;
 	type InflationRewardPerSession = InflationRewardPerSession;
 	type RoleKeyId = RoleKeyId;
 	type ValidatorRewardDistribution = Reward;
 	type ValidatorSet = Historical;
 	type ReportOffences = OffenceHandler;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxRolesPerValidator = MaxActiveJobsPerValidator;
 	type WeightInfo = ();
 }
 
 parameter_types! {
 	pub const JobsPalletId: PalletId = PalletId(*b"py/jobss");
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxParticipants: u32 = 10;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSubmissionLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxKeyLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxDataLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSignatureLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxProofLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxActiveJobsPerValidator: u32 = 100;
 }
 
 impl Config for Runtime {
@@ -315,6 +358,13 @@ impl Config for Runtime {
 	type RolesHandler = Roles;
 	type MPCHandler = MockMPCHandler;
 	type PalletId = JobsPalletId;
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
+	type MaxActiveJobsPerValidator = MaxActiveJobsPerValidator;
 	type WeightInfo = ();
 }
 

--- a/pallets/jobs/src/rpc.rs
+++ b/pallets/jobs/src/rpc.rs
@@ -1,6 +1,7 @@
 use super::*;
+use crate::types::{PhaseResultOf, RpcResponseJobsDataOf};
 pub use tangle_primitives::jobs::RpcResponseJobsData;
-use tangle_primitives::{jobs::PhaseResult, roles::RoleType};
+use tangle_primitives::roles::RoleType;
 
 impl<T: Config> Pallet<T> {
 	/// Queries jobs associated with a specific validator.
@@ -20,12 +21,12 @@ impl<T: Config> Pallet<T> {
 	/// operation is successful, or an error message as a `String` if there is an issue.
 	pub fn query_jobs_by_validator(
 		validator: T::AccountId,
-	) -> Option<Vec<RpcResponseJobsData<T::AccountId, BlockNumberFor<T>>>> {
-		let mut jobs: Vec<RpcResponseJobsData<_, _>> = vec![];
+	) -> Option<Vec<RpcResponseJobsDataOf<T>>> {
+		let mut jobs: Vec<RpcResponseJobsDataOf<T>> = vec![];
 		if let Some(jobs_list) = ValidatorJobIdLookup::<T>::get(validator) {
 			for (role_type, job_id) in jobs_list.iter() {
 				if let Some(job_info) = SubmittedJobs::<T>::get(role_type, job_id) {
-					let info = RpcResponseJobsData::<T::AccountId, BlockNumberFor<T>> {
+					let info = RpcResponseJobsData {
 						job_id: *job_id,
 						job_type: job_info.job_type,
 						ttl: job_info.ttl,
@@ -51,10 +52,7 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	///
 	/// An optional `RpcResponseJobsData` containing the account ID of the job.
-	pub fn query_job_by_id(
-		role_type: RoleType,
-		job_id: JobId,
-	) -> Option<RpcResponseJobsData<T::AccountId, BlockNumberFor<T>>> {
+	pub fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsDataOf<T>> {
 		SubmittedJobs::<T>::get(role_type, job_id).map(|job_info| RpcResponseJobsData {
 			job_id,
 			job_type: job_info.job_type,
@@ -74,10 +72,7 @@ impl<T: Config> Pallet<T> {
 	///
 	/// An `Option` containing the phase one result of the job, wrapped in an
 	/// `PhaseResult`.
-	pub fn query_job_result(
-		role_type: RoleType,
-		job_id: JobId,
-	) -> Option<PhaseResult<T::AccountId, BlockNumberFor<T>>> {
+	pub fn query_job_result(role_type: RoleType, job_id: JobId) -> Option<PhaseResultOf<T>> {
 		KnownResults::<T>::get(role_type, job_id)
 	}
 

--- a/pallets/jobs/src/tests.rs
+++ b/pallets/jobs/src/tests.rs
@@ -85,7 +85,9 @@ fn jobs_submission_e2e_works_for_dkg() {
 				participants: [HUNDRED, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: None,
 				role_type: threshold_signature_role_type,
@@ -114,7 +116,9 @@ fn jobs_submission_e2e_works_for_dkg() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 5,
 				permitted_caller: None,
 				role_type: threshold_signature_role_type,
@@ -135,7 +139,9 @@ fn jobs_submission_e2e_works_for_dkg() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: None,
 				role_type: threshold_signature_role_type,
@@ -155,7 +161,9 @@ fn jobs_submission_e2e_works_for_dkg() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -171,10 +179,10 @@ fn jobs_submission_e2e_works_for_dkg() {
 			RoleType::Tss(ThresholdSignatureRoleType::ZengoGG20Secp256k1),
 			0,
 			JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
-				signatures: vec![],
+				signatures: vec![].try_into().unwrap(),
 				threshold: 3,
-				participants: vec![],
-				key: vec![],
+				participants: vec![].try_into().unwrap(),
+				key: vec![].try_into().unwrap(),
 				signature_type: DigitalSignatureType::Ecdsa
 			})
 		));
@@ -204,7 +212,7 @@ fn jobs_submission_e2e_works_for_dkg() {
 			ttl: 0,
 			job_type: JobType::DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType {
 				phase_one_id: 0,
-				submission: vec![],
+				submission: vec![].try_into().unwrap(),
 				role_type: threshold_signature_role_type,
 			}),
 		};
@@ -218,7 +226,7 @@ fn jobs_submission_e2e_works_for_dkg() {
 			ttl: 0,
 			job_type: JobType::DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType {
 				phase_one_id: 0,
-				submission: vec![],
+				submission: vec![].try_into().unwrap(),
 				role_type: threshold_signature_role_type,
 			}),
 		};
@@ -232,9 +240,9 @@ fn jobs_submission_e2e_works_for_dkg() {
 			RoleType::Tss(threshold_signature_role_type),
 			1,
 			JobResult::DKGPhaseTwo(DKGTSSSignatureResult {
-				signing_key: vec![],
-				signature: vec![],
-				data: vec![],
+				signing_key: vec![].try_into().unwrap(),
+				signature: vec![].try_into().unwrap(),
+				data: vec![].try_into().unwrap(),
 				signature_type: DigitalSignatureType::Ecdsa
 			})
 		));
@@ -282,7 +290,9 @@ fn jobs_submission_e2e_for_dkg_refresh() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -298,10 +308,10 @@ fn jobs_submission_e2e_for_dkg_refresh() {
 			RoleType::Tss(ThresholdSignatureRoleType::ZengoGG20Secp256k1),
 			0,
 			JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
-				signatures: vec![],
+				signatures: vec![].try_into().unwrap(),
 				threshold: 3,
-				participants: vec![],
-				key: vec![],
+				participants: vec![].try_into().unwrap(),
+				key: vec![].try_into().unwrap(),
 				signature_type: DigitalSignatureType::Ecdsa
 			})
 		));
@@ -361,7 +371,9 @@ fn jobs_submission_e2e_for_dkg_rotation() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -378,7 +390,9 @@ fn jobs_submission_e2e_for_dkg_rotation() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -393,10 +407,10 @@ fn jobs_submission_e2e_for_dkg_rotation() {
 			RoleType::Tss(ThresholdSignatureRoleType::ZengoGG20Secp256k1),
 			0,
 			JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
-				signatures: vec![],
+				signatures: vec![].try_into().unwrap(),
 				threshold: 3,
-				participants: vec![],
-				key: vec![],
+				participants: vec![].try_into().unwrap(),
+				key: vec![].try_into().unwrap(),
 				signature_type: DigitalSignatureType::Ecdsa
 			})
 		));
@@ -407,10 +421,10 @@ fn jobs_submission_e2e_for_dkg_rotation() {
 			RoleType::Tss(ThresholdSignatureRoleType::ZengoGG20Secp256k1),
 			1,
 			JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
-				signatures: vec![],
+				signatures: vec![].try_into().unwrap(),
 				threshold: 3,
-				participants: vec![],
-				key: vec![],
+				participants: vec![].try_into().unwrap(),
+				key: vec![].try_into().unwrap(),
 				signature_type: DigitalSignatureType::Ecdsa
 			})
 		));
@@ -436,9 +450,9 @@ fn jobs_submission_e2e_for_dkg_rotation() {
 			RoleType::Tss(threshold_signature_role_type),
 			2,
 			JobResult::DKGPhaseFour(DKGTSSKeyRotationResult {
-				key: vec![],
-				new_key: vec![],
-				signature: vec![],
+				key: vec![].try_into().unwrap(),
+				new_key: vec![].try_into().unwrap(),
+				signature: vec![].try_into().unwrap(),
 				phase_one_id: 0,
 				new_phase_one_id: 1,
 				signature_type: DigitalSignatureType::Ecdsa
@@ -474,7 +488,13 @@ fn jobs_rpc_tests() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -511,10 +531,10 @@ fn jobs_rpc_tests() {
 			RoleType::Tss(ThresholdSignatureRoleType::ZengoGG20Secp256k1),
 			0,
 			JobResult::DKGPhaseOne(DKGTSSKeySubmissionResult {
-				signatures: vec![],
+				signatures: vec![].try_into().unwrap(),
 				threshold: 3,
-				participants: vec![],
-				key: vec![],
+				participants: vec![].try_into().unwrap(),
+				key: vec![].try_into().unwrap(),
 				signature_type: DigitalSignatureType::Ecdsa
 			})
 		));
@@ -536,7 +556,7 @@ fn jobs_rpc_tests() {
 			ttl: 0,
 			job_type: JobType::DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType {
 				phase_one_id: 0,
-				submission: vec![],
+				submission: vec![].try_into().unwrap(),
 				role_type: threshold_signature_role_type,
 			}),
 		};
@@ -583,12 +603,12 @@ fn jobs_submission_e2e_works_for_zksaas() {
 		}
 
 		let dummy_system = ZkSaaSSystem::Groth16(Groth16System {
-			circuit: HyperData::Raw(vec![]),
+			circuit: HyperData::Raw(vec![].try_into().unwrap()),
 			num_inputs: 0,
 			num_constraints: 0,
-			proving_key: HyperData::Raw(vec![]),
-			verifying_key: vec![],
-			wasm: HyperData::Raw(vec![]),
+			proving_key: HyperData::Raw(vec![].try_into().unwrap()),
+			verifying_key: vec![].try_into().unwrap(),
+			wasm: HyperData::Raw(vec![].try_into().unwrap()),
 		});
 
 		let submission = JobSubmission {
@@ -601,7 +621,9 @@ fn jobs_submission_e2e_works_for_zksaas() {
 				participants: [HUNDRED, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect::<Vec<_>>(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 			}),
 		};
 
@@ -615,14 +637,20 @@ fn jobs_submission_e2e_works_for_zksaas() {
 		let _submission = JobSubmission {
 			expiry: 10,
 			ttl: 200,
-			job_type: JobType::ZkSaaSPhaseOne(ZkSaaSPhaseOneJobType {
+			job_type: JobType::ZkSaaSPhaseOne(ZkSaaSPhaseOneJobType::<
+				sp_runtime::AccountId32,
+				MaxParticipants,
+				MaxSubmissionLen,
+			> {
 				permitted_caller: None,
 				system: dummy_system.clone(),
 				role_type: ZeroKnowledgeRoleType::ZkSaaSGroth16,
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect::<Vec<_>>(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 			}),
 		};
 
@@ -636,7 +664,9 @@ fn jobs_submission_e2e_works_for_zksaas() {
 				participants: [ALICE, BOB, CHARLIE, DAVE, EVE]
 					.iter()
 					.map(|x| mock_pub_key(*x))
-					.collect::<Vec<_>>(),
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 			}),
 		};
 		assert_ok!(Jobs::submit_job(RuntimeOrigin::signed(mock_pub_key(TEN)), submission));
@@ -648,7 +678,10 @@ fn jobs_submission_e2e_works_for_zksaas() {
 			RuntimeOrigin::signed(mock_pub_key(TEN)),
 			RoleType::ZkSaaS(ZeroKnowledgeRoleType::ZkSaaSGroth16),
 			0,
-			JobResult::ZkSaaSPhaseOne(ZkSaaSCircuitResult { job_id: 0, participants: vec![] }),
+			JobResult::ZkSaaSPhaseOne(ZkSaaSCircuitResult {
+				job_id: 0,
+				participants: vec![].try_into().unwrap()
+			}),
 		));
 
 		// ensure the job reward is distributed correctly
@@ -670,10 +703,10 @@ fn jobs_submission_e2e_works_for_zksaas() {
 
 		// ---- use phase one solution in phase 2 proving -------
 		let dummy_req = ZkSaaSPhaseTwoRequest::Groth16(Groth16ProveRequest {
-			public_input: vec![],
-			a_shares: vec![],
-			ax_shares: vec![],
-			qap_shares: vec![],
+			public_input: vec![].try_into().unwrap(),
+			a_shares: vec![].try_into().unwrap(),
+			ax_shares: vec![].try_into().unwrap(),
+			qap_shares: vec![].try_into().unwrap(),
 		});
 		// another account cannot use solution
 		let submission = JobSubmission {
@@ -749,7 +782,13 @@ fn reduce_active_role_restake_should_fail() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -807,7 +846,13 @@ fn delete_profile_with_active_role_should_fail() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -847,7 +892,13 @@ fn remove_active_role_should_fail() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -898,7 +949,13 @@ fn remove_role_without_active_jobs_should_work() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -947,7 +1004,13 @@ fn add_role_to_active_profile_should_work() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -1002,7 +1065,13 @@ fn reduce_stake_on_non_active_role_should_work() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -1056,7 +1125,13 @@ fn increase_stake_on_active_role_should_work() {
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -1172,7 +1247,13 @@ fn switch_active_shared_profile_to_independent_should_work_if_active_stake_prese
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,
@@ -1251,7 +1332,13 @@ fn switch_active_independent_profile_to_shared_should_work_if_active_restake_sum
 			expiry: 10,
 			ttl: 200,
 			job_type: JobType::DKGTSSPhaseOne(DKGTSSPhaseOneJobType {
-				participants: participants.clone().iter().map(|x| mock_pub_key(*x)).collect(),
+				participants: participants
+					.clone()
+					.iter()
+					.map(|x| mock_pub_key(*x))
+					.collect::<Vec<_>>()
+					.try_into()
+					.unwrap(),
 				threshold: 3,
 				permitted_caller: Some(mock_pub_key(TEN)),
 				role_type: threshold_signature_role_type,

--- a/pallets/jobs/src/types.rs
+++ b/pallets/jobs/src/types.rs
@@ -16,13 +16,69 @@
 use super::*;
 use tangle_primitives::jobs::*;
 
-pub type JobSubmissionOf<T> =
-	JobSubmission<<T as frame_system::Config>::AccountId, BlockNumberFor<T>>;
+pub type JobSubmissionOf<T> = JobSubmission<
+	<T as frame_system::Config>::AccountId,
+	BlockNumberFor<T>,
+	<T as Config>::MaxParticipants,
+	<T as Config>::MaxSubmissionLen,
+>;
 
-pub type JobInfoOf<T> =
-	JobInfo<<T as frame_system::Config>::AccountId, BlockNumberFor<T>, BalanceOf<T>>;
+pub type JobInfoOf<T> = JobInfo<
+	<T as frame_system::Config>::AccountId,
+	BlockNumberFor<T>,
+	BalanceOf<T>,
+	<T as Config>::MaxParticipants,
+	<T as Config>::MaxSubmissionLen,
+>;
 
 pub type BalanceOf<T> =
 	<<T as Config>::Currency as Currency<<T as frame_system::Config>::AccountId>>::Balance;
 
-pub type PhaseResultOf<T> = PhaseResult<<T as frame_system::Config>::AccountId, BlockNumberFor<T>>;
+pub type PhaseResultOf<T> = PhaseResult<
+	<T as frame_system::Config>::AccountId,
+	BlockNumberFor<T>,
+	<T as Config>::MaxParticipants,
+	<T as Config>::MaxKeyLen,
+	<T as Config>::MaxDataLen,
+	<T as Config>::MaxSignatureLen,
+	<T as Config>::MaxSubmissionLen,
+	<T as Config>::MaxProofLen,
+>;
+
+pub type JobResultOf<T> = JobResult<
+	<T as Config>::MaxParticipants,
+	<T as Config>::MaxKeyLen,
+	<T as Config>::MaxSignatureLen,
+	<T as Config>::MaxDataLen,
+	<T as Config>::MaxProofLen,
+>;
+
+pub type DKGTSSKeySubmissionResultOf<T> = DKGTSSKeySubmissionResult<
+	<T as Config>::MaxKeyLen,
+	<T as Config>::MaxParticipants,
+	<T as Config>::MaxSignatureLen,
+>;
+
+pub type DKGTSSSignatureResultOf<T> = DKGTSSSignatureResult<
+	<T as Config>::MaxDataLen,
+	<T as Config>::MaxKeyLen,
+	<T as Config>::MaxSignatureLen,
+>;
+
+pub type DKGTSSKeyRotationResultOf<T> =
+	DKGTSSKeyRotationResult<<T as Config>::MaxKeyLen, <T as Config>::MaxSignatureLen>;
+
+pub type ZkSaaSCircuitResultOf<T> = ZkSaaSCircuitResult<<T as Config>::MaxParticipants>;
+
+pub type ZkSaaSProofResultOf<T> = ZkSaaSProofResult<<T as Config>::MaxProofLen>;
+
+pub type RpcResponseJobsDataOf<T> = RpcResponseJobsData<
+	<T as frame_system::Config>::AccountId,
+	BlockNumberFor<T>,
+	<T as Config>::MaxParticipants,
+	<T as Config>::MaxSubmissionLen,
+>;
+
+pub type ParticipantKeysOf<T> = BoundedVec<ParticipantKeyOf<T>, <T as Config>::MaxParticipants>;
+
+pub type ParticipantKeyOf<T> = BoundedVec<u8, <T as Config>::MaxKeyLen>;

--- a/pallets/roles/src/impls.rs
+++ b/pallets/roles/src/impls.rs
@@ -65,7 +65,7 @@ impl<T: Config> RolesHandler<T::AccountId> for Pallet<T> {
 	fn get_validator_role_key(address: T::AccountId) -> Option<Vec<u8>> {
 		let maybe_ledger = Self::ledger(&address);
 		if let Some(ledger) = maybe_ledger {
-			Some(ledger.role_key)
+			Some(ledger.role_key.to_vec())
 		} else {
 			return None
 		}
@@ -350,7 +350,9 @@ impl<T: Config> Pallet<T> {
 
 	pub fn update_ledger_role_key(staker: &T::AccountId, role_key: Vec<u8>) -> DispatchResult {
 		let mut ledger = Ledger::<T>::get(staker).ok_or(Error::<T>::NoProfileFound)?;
-		ledger.role_key = role_key;
+		let bounded_role_key: BoundedVec<u8, T::MaxKeyLen> =
+			role_key.try_into().map_err(|_| Error::<T>::KeySizeExceeded)?;
+		ledger.role_key = bounded_role_key;
 		Self::update_ledger(staker, &ledger);
 		Ok(())
 	}

--- a/pallets/roles/src/profile.rs
+++ b/pallets/roles/src/profile.rs
@@ -21,7 +21,14 @@ use sp_std::vec::Vec;
 use tangle_primitives::roles::RoleType;
 
 #[derive(
-	PartialEqNoBound, EqNoBound, CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo,
+	PartialEqNoBound,
+	EqNoBound,
+	CloneNoBound,
+	Encode,
+	Decode,
+	RuntimeDebugNoBound,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(T))]
 pub struct Record<T: Config> {
@@ -30,7 +37,14 @@ pub struct Record<T: Config> {
 }
 
 #[derive(
-	PartialEqNoBound, EqNoBound, CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo,
+	PartialEqNoBound,
+	EqNoBound,
+	CloneNoBound,
+	Encode,
+	Decode,
+	RuntimeDebugNoBound,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(T))]
 pub struct IndependentRestakeProfile<T: Config> {
@@ -38,7 +52,14 @@ pub struct IndependentRestakeProfile<T: Config> {
 }
 
 #[derive(
-	PartialEqNoBound, EqNoBound, CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo,
+	PartialEqNoBound,
+	EqNoBound,
+	CloneNoBound,
+	Encode,
+	Decode,
+	RuntimeDebugNoBound,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(T))]
 pub struct SharedRestakeProfile<T: Config> {
@@ -47,7 +68,14 @@ pub struct SharedRestakeProfile<T: Config> {
 }
 
 #[derive(
-	PartialEqNoBound, EqNoBound, CloneNoBound, Encode, Decode, RuntimeDebugNoBound, TypeInfo,
+	PartialEqNoBound,
+	EqNoBound,
+	CloneNoBound,
+	Encode,
+	Decode,
+	RuntimeDebugNoBound,
+	TypeInfo,
+	MaxEncodedLen,
 )]
 #[scale_info(skip_type_params(T))]
 pub enum Profile<T: Config> {

--- a/pallets/zksaas/src/functions.rs
+++ b/pallets/zksaas/src/functions.rs
@@ -33,7 +33,14 @@ impl<T: Config> Pallet<T> {
 	/// # Returns
 	///
 	/// Returns the calculated fee as a `BalanceOf<T>` type.
-	pub fn job_to_fee(job: &JobSubmission<T::AccountId, BlockNumberFor<T>>) -> BalanceOf<T> {
+	pub fn job_to_fee(
+		job: &JobSubmission<
+			T::AccountId,
+			BlockNumberFor<T>,
+			T::MaxParticipants,
+			T::MaxSubmissionLen,
+		>,
+	) -> BalanceOf<T> {
 		let fee_info = FeeInfo::<T>::get();
 		// charge the base fee + per validator fee
 		if job.job_type.is_phase_one() {
@@ -58,7 +65,18 @@ impl<T: Config> Pallet<T> {
 	///
 	/// Returns a `DispatchResult` indicating whether the verification was successful or encountered
 	/// an error.
-	pub fn verify(data: JobWithResult<T::AccountId>) -> DispatchResult {
+	#[allow(clippy::type_complexity)]
+	pub fn verify(
+		data: JobWithResult<
+			T::AccountId,
+			T::MaxParticipants,
+			T::MaxSubmissionLen,
+			T::MaxKeyLen,
+			T::MaxDataLen,
+			T::MaxSignatureLen,
+			T::MaxProofLen,
+		>,
+	) -> DispatchResult {
 		match (data.phase_one_job_type, data.job_type, data.result) {
 			(None, _, JobResult::ZkSaaSPhaseOne(_)) => Ok(()),
 			(
@@ -72,9 +90,13 @@ impl<T: Config> Pallet<T> {
 
 	/// Verifies a given proof submission.
 	pub fn verify_proof(
-		ZkSaaSPhaseOneJobType { system, .. }: ZkSaaSPhaseOneJobType<T::AccountId>,
-		ZkSaaSPhaseTwoJobType { request, .. }: ZkSaaSPhaseTwoJobType,
-		res: ZkSaaSProofResult,
+		ZkSaaSPhaseOneJobType { system, .. }: ZkSaaSPhaseOneJobType<
+			T::AccountId,
+			T::MaxParticipants,
+			T::MaxSubmissionLen,
+		>,
+		ZkSaaSPhaseTwoJobType { request, .. }: ZkSaaSPhaseTwoJobType<T::MaxSubmissionLen>,
+		res: ZkSaaSProofResult<T::MaxProofLen>,
 	) -> DispatchResult {
 		match (system, request, res) {
 			(
@@ -92,9 +114,9 @@ impl<T: Config> Pallet<T> {
 
 	/// Verifies a given circom proof submission.
 	pub fn verify_circom_proof(
-		system: Groth16System,
-		req: Groth16ProveRequest,
-		res: CircomProofResult,
+		system: Groth16System<T::MaxSubmissionLen>,
+		req: Groth16ProveRequest<T::MaxSubmissionLen>,
+		res: CircomProofResult<T::MaxProofLen>,
 	) -> DispatchResult {
 		let maybe_verified =
 			T::Verifier::verify(&req.public_input, &res.proof, &system.verifying_key);
@@ -110,9 +132,9 @@ impl<T: Config> Pallet<T> {
 
 	/// Verifies a given arkworks proof submission.
 	pub fn verify_arkworks_proof(
-		system: Groth16System,
-		req: Groth16ProveRequest,
-		res: ArkworksProofResult,
+		system: Groth16System<T::MaxSubmissionLen>,
+		req: Groth16ProveRequest<T::MaxSubmissionLen>,
+		res: ArkworksProofResult<T::MaxProofLen>,
 	) -> DispatchResult {
 		let maybe_verified =
 			T::Verifier::verify(&req.public_input, &res.proof, &system.verifying_key);

--- a/pallets/zksaas/src/lib.rs
+++ b/pallets/zksaas/src/lib.rs
@@ -41,6 +41,7 @@ pub mod pallet {
 		traits::{Get, ReservableCurrency},
 	};
 	use frame_system::pallet_prelude::*;
+	use scale_info::prelude::fmt::Debug;
 	use tangle_primitives::verifier::InstanceVerifier;
 
 	/// Configure the pallet by specifying the parameters and types on which it depends.
@@ -57,6 +58,24 @@ pub mod pallet {
 
 		/// The verifier instance trait
 		type Verifier: InstanceVerifier;
+
+		/// The maximum participants allowed in a job
+		type MaxParticipants: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of job result submission
+		type MaxSubmissionLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of a signature
+		type MaxSignatureLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of data to be signed
+		type MaxDataLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of validator key allowed
+		type MaxKeyLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
+
+		/// The maximum size of proof allowed
+		type MaxProofLen: Get<u32> + Clone + TypeInfo + Debug + Eq + PartialEq;
 
 		/// Weight info for pallet
 		type WeightInfo: WeightInfo;

--- a/pallets/zksaas/src/mock.rs
+++ b/pallets/zksaas/src/mock.rs
@@ -84,15 +84,15 @@ parameter_types! {
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxParticipants: u32 = 10;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = u32::MAX;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxKeyLen: u32 = 256;
+	pub const MaxKeyLen: u32 = u32::MAX;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxDataLen: u32 = 256;
+	pub const MaxDataLen: u32 = u32::MAX;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxSignatureLen: u32 = 256;
+	pub const MaxSignatureLen: u32 = u32::MAX;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxProofLen: u32 = 256;
+	pub const MaxProofLen: u32 = u32::MAX; // TODO : Figure out sensible limits for zksaas
 }
 
 impl Config for Runtime {

--- a/pallets/zksaas/src/mock.rs
+++ b/pallets/zksaas/src/mock.rs
@@ -18,10 +18,11 @@
 use super::*;
 use crate as pallet_zksaas;
 use frame_support::{
-	construct_runtime,
+	construct_runtime, parameter_types,
 	traits::{ConstU128, ConstU32, ConstU64, Everything},
 };
 use frame_system::EnsureSignedBy;
+use scale_info::TypeInfo;
 use sp_core::H256;
 use sp_keystore::{testing::MemoryKeystore, KeystoreExt, KeystorePtr};
 use sp_runtime::{testing::Header, traits::IdentityLookup, BuildStorage};
@@ -79,11 +80,32 @@ frame_support::ord_parameter_types! {
 	pub const One: AccountId = 1;
 }
 
+parameter_types! {
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxParticipants: u32 = 10;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSubmissionLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxKeyLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxDataLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSignatureLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxProofLen: u32 = 256;
+}
+
 impl Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type UpdateOrigin = EnsureSignedBy<One, AccountId>;
 	type Verifier = (ArkworksVerifierGroth16Bn254, CircomVerifierGroth16Bn254);
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
 	type WeightInfo = ();
 }
 

--- a/pallets/zksaas/src/tests.rs
+++ b/pallets/zksaas/src/tests.rs
@@ -101,37 +101,49 @@ fn proof_verification_works() {
 
 		// Phase1
 		let zero_knowledge_role_type = ZeroKnowledgeRoleType::ZkSaaSGroth16;
-		let phase_one = JobType::<AccountId>::ZkSaaSPhaseOne(ZkSaaSPhaseOneJobType {
-			role_type: zero_knowledge_role_type,
-			participants: vec![1, 2, 3, 4, 5, 6, 7, 8],
-			system: ZkSaaSSystem::Groth16(Groth16System {
-				circuit: HyperData::Raw(vec![]),
-				num_inputs: num_inputs as _,
-				num_constraints: num_constraints as _,
-				proving_key: HyperData::Raw(pk_bytes),
-				verifying_key: vk_bytes,
-				wasm: HyperData::Raw(vec![]),
-			}),
-			permitted_caller: None,
-		});
+		let phase_one = JobType::<AccountId, MaxParticipants, MaxSubmissionLen>::ZkSaaSPhaseOne(
+			ZkSaaSPhaseOneJobType {
+				role_type: zero_knowledge_role_type,
+				participants: vec![1, 2, 3, 4, 5, 6, 7, 8].try_into().unwrap(),
+				system: ZkSaaSSystem::Groth16(Groth16System {
+					circuit: HyperData::Raw(vec![].try_into().unwrap()),
+					num_inputs: num_inputs as _,
+					num_constraints: num_constraints as _,
+					proving_key: HyperData::Raw(pk_bytes.try_into().unwrap()),
+					verifying_key: vk_bytes.try_into().unwrap(),
+					wasm: HyperData::Raw(vec![].try_into().unwrap()),
+				}),
+				permitted_caller: None,
+			},
+		);
 
-		let phase_two = JobType::<AccountId>::ZkSaaSPhaseTwo(ZkSaaSPhaseTwoJobType {
-			role_type: zero_knowledge_role_type,
-			phase_one_id: 0,
-			request: ZkSaaSPhaseTwoRequest::Groth16(Groth16ProveRequest {
-				public_input: from_field_elements(&[image]).unwrap(),
-				a_shares: Default::default(),
-				ax_shares: Default::default(),
-				qap_shares: Default::default(),
-			}),
-		});
+		let phase_two = JobType::<AccountId, MaxParticipants, MaxSubmissionLen>::ZkSaaSPhaseTwo(
+			ZkSaaSPhaseTwoJobType {
+				role_type: zero_knowledge_role_type,
+				phase_one_id: 0,
+				request: ZkSaaSPhaseTwoRequest::Groth16(Groth16ProveRequest {
+					public_input: from_field_elements(&[image]).unwrap().try_into().unwrap(),
+					a_shares: Default::default(),
+					ax_shares: Default::default(),
+					qap_shares: Default::default(),
+				}),
+			},
+		);
 
 		// Arkworks
 		let result = JobResult::ZkSaaSPhaseTwo(ZkSaaSProofResult::Arkworks(ArkworksProofResult {
-			proof: proof_bytes,
+			proof: proof_bytes.try_into().unwrap(),
 		}));
 
-		let data = JobWithResult::<AccountId> {
+		let data = JobWithResult::<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		> {
 			job_type: phase_two.clone(),
 			phase_one_job_type: Some(phase_one.clone()),
 			result,
@@ -143,10 +155,18 @@ fn proof_verification_works() {
 		let circom_proof = verifier::circom::Proof::try_from(proof).unwrap();
 
 		let result = JobResult::ZkSaaSPhaseTwo(ZkSaaSProofResult::Circom(CircomProofResult {
-			proof: circom_proof.encode().unwrap(),
+			proof: circom_proof.encode().unwrap().try_into().unwrap(),
 		}));
 
-		let data = JobWithResult::<AccountId> {
+		let data = JobWithResult::<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		> {
 			job_type: phase_two,
 			phase_one_job_type: Some(phase_one),
 			result,

--- a/precompiles/jobs/src/lib.rs
+++ b/precompiles/jobs/src/lib.rs
@@ -91,7 +91,9 @@ where
 		let participants = participants
 			.iter()
 			.map(|x| Runtime::AddressMapping::into_account_id(x.0))
-			.collect();
+			.collect::<Vec<_>>()
+			.try_into()
+			.unwrap();
 
 		// Convert (u16) role type to RoleType
 		let role_type = Self::convert_role_type(role_type);
@@ -168,7 +170,7 @@ where
 		submission: BoundedBytes<GetJobSubmissionSizeLimit>,
 	) -> EvmResult {
 		// Convert BoundedBytes to Vec<u8>
-		let submission: Vec<u8> = submission.into();
+		let submission: Vec<u8> = submission.try_into().unwrap();
 
 		// Convert caller's Ethereum address to Substrate account ID
 		let origin = Runtime::AddressMapping::into_account_id(handle.context().caller);
@@ -194,7 +196,7 @@ where
 				let job_type = DKGTSSPhaseTwoJobType {
 					role_type: threshold_signature_role,
 					phase_one_id,
-					submission,
+					submission: submission.try_into().unwrap(),
 				};
 
 				// Create job submission object

--- a/precompiles/jobs/src/mock.rs
+++ b/precompiles/jobs/src/mock.rs
@@ -20,6 +20,7 @@ use frame_support::{
 use frame_system::EnsureSigned;
 use pallet_evm::{EnsureAddressNever, EnsureAddressRoot};
 use precompile_utils::{precompile_set::*, testing::MockAccount};
+use scale_info::TypeInfo;
 use sp_core::{H256, U256};
 use sp_runtime::{
 	traits::{BlakeTwo256, IdentityLookup},
@@ -154,7 +155,9 @@ impl pallet_timestamp::Config for Runtime {
 
 pub struct MockDKGPallet;
 impl MockDKGPallet {
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		if job.job_type.is_phase_one() {
 			job.job_type.clone().get_participants().unwrap().len().try_into().unwrap()
 		} else {
@@ -165,7 +168,9 @@ impl MockDKGPallet {
 
 pub struct MockZkSaasPallet;
 impl MockZkSaasPallet {
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		if job.job_type.is_phase_one() {
 			10
 		} else {
@@ -176,10 +181,12 @@ impl MockZkSaasPallet {
 
 pub struct MockJobToFeeHandler;
 
-impl JobToFee<AccountId, BlockNumber> for MockJobToFeeHandler {
+impl JobToFee<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen> for MockJobToFeeHandler {
 	type Balance = Balance;
 
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		match job.job_type {
 			JobType::DKGTSSPhaseOne(_) |
 			JobType::DKGTSSPhaseTwo(_) |
@@ -216,8 +223,30 @@ impl RolesHandler<AccountId> for MockRolesHandler {
 
 pub struct MockMPCHandler;
 
-impl MPCHandler<AccountId, BlockNumber, Balance> for MockMPCHandler {
-	fn verify(_data: JobWithResult<AccountId>) -> DispatchResult {
+impl
+	MPCHandler<
+		AccountId,
+		BlockNumber,
+		Balance,
+		MaxParticipants,
+		MaxSubmissionLen,
+		MaxKeyLen,
+		MaxDataLen,
+		MaxSignatureLen,
+		MaxProofLen,
+	> for MockMPCHandler
+{
+	fn verify(
+		_data: JobWithResult<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		>,
+	) -> DispatchResult {
 		Ok(())
 	}
 
@@ -236,6 +265,20 @@ impl MPCHandler<AccountId, BlockNumber, Balance> for MockMPCHandler {
 
 parameter_types! {
 	pub const JobsPalletId: PalletId = PalletId(*b"py/jobss");
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxParticipants: u32 = 10;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSubmissionLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxKeyLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxDataLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSignatureLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxProofLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxActiveJobsPerValidator: u32 = 100;
 }
 
 impl pallet_jobs::Config for Runtime {
@@ -246,6 +289,13 @@ impl pallet_jobs::Config for Runtime {
 	type RolesHandler = MockRolesHandler;
 	type MPCHandler = MockMPCHandler;
 	type PalletId = JobsPalletId;
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
+	type MaxActiveJobsPerValidator = MaxActiveJobsPerValidator;
 	type WeightInfo = ();
 }
 

--- a/primitives/src/jobs/mod.rs
+++ b/primitives/src/jobs/mod.rs
@@ -19,6 +19,7 @@ use frame_support::pallet_prelude::*;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
+use sp_runtime::traits::Get;
 use sp_std::vec::Vec;
 
 pub type JobId = u64;
@@ -31,8 +32,13 @@ pub use tss::*;
 pub use zksaas::*;
 
 /// Represents a job submission with specified `AccountId` and `BlockNumber`.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
-pub struct JobSubmission<AccountId, BlockNumber> {
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
+pub struct JobSubmission<
+	AccountId,
+	BlockNumber,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+> {
 	/// Represents the maximum allowed submission time for a job result.
 	/// Once this time has passed, the result cannot be submitted.
 	pub expiry: BlockNumber,
@@ -42,12 +48,18 @@ pub struct JobSubmission<AccountId, BlockNumber> {
 	pub ttl: BlockNumber,
 
 	/// The type of the job submission.
-	pub job_type: JobType<AccountId>,
+	pub job_type: JobType<AccountId, MaxParticipants, MaxSubmissionLen>,
 }
 
 /// Represents a job info
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
-pub struct JobInfo<AccountId, BlockNumber, Balance> {
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
+pub struct JobInfo<
+	AccountId,
+	BlockNumber,
+	Balance,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+> {
 	/// The caller that requested the job
 	pub owner: AccountId,
 
@@ -60,61 +72,54 @@ pub struct JobInfo<AccountId, BlockNumber, Balance> {
 	pub ttl: BlockNumber,
 
 	/// The type of the job submission.
-	pub job_type: JobType<AccountId>,
+	pub job_type: JobType<AccountId, MaxParticipants, MaxSubmissionLen>,
 
 	/// The fee taken for the job
 	pub fee: Balance,
 }
 
 /// Represents a job with its result.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
-pub struct JobWithResult<AccountId> {
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
+pub struct JobWithResult<
+	AccountId,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+	MaxKeyLen: Get<u32>,
+	MaxDataLen: Get<u32>,
+	MaxSignatureLen: Get<u32>,
+	MaxProofLen: Get<u32>,
+> {
 	/// Current Job type
-	pub job_type: JobType<AccountId>,
+	pub job_type: JobType<AccountId, MaxParticipants, MaxSubmissionLen>,
 	/// Phase one job type if any.
 	///
 	/// None if this job is a phase one job.
-	pub phase_one_job_type: Option<JobType<AccountId>>,
+	pub phase_one_job_type: Option<JobType<AccountId, MaxParticipants, MaxSubmissionLen>>,
 	/// Current job result
-	pub result: JobResult,
+	pub result: JobResult<MaxParticipants, MaxKeyLen, MaxSignatureLen, MaxDataLen, MaxProofLen>,
 }
 
 /// Enum representing different types of jobs.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum JobType<AccountId> {
+pub enum JobType<AccountId, MaxParticipants: Get<u32> + Clone, MaxSubmissionLen: Get<u32>> {
 	/// Distributed Key Generation (DKG) job type.
-	DKGTSSPhaseOne(DKGTSSPhaseOneJobType<AccountId>),
+	DKGTSSPhaseOne(DKGTSSPhaseOneJobType<AccountId, MaxParticipants>),
 	/// DKG Signature job type.
-	DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType),
+	DKGTSSPhaseTwo(DKGTSSPhaseTwoJobType<MaxSubmissionLen>),
 	/// DKG Key Refresh job type.
 	DKGTSSPhaseThree(DKGTSSPhaseThreeJobType),
 	/// DKG Key Rotation job type.
 	DKGTSSPhaseFour(DKGTSSPhaseFourJobType),
 	/// (zk-SNARK) Create Circuit job type.
-	ZkSaaSPhaseOne(ZkSaaSPhaseOneJobType<AccountId>),
+	ZkSaaSPhaseOne(ZkSaaSPhaseOneJobType<AccountId, MaxParticipants, MaxSubmissionLen>),
 	/// (zk-SNARK) Create Proof job type.
-	ZkSaaSPhaseTwo(ZkSaaSPhaseTwoJobType),
+	ZkSaaSPhaseTwo(ZkSaaSPhaseTwoJobType<MaxSubmissionLen>),
 }
 
-/// Enum representing different types of data sources.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
-#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum HyperData {
-	/// Raw data, stored on-chain.
-	///
-	/// Only use this for small files.
-	Raw(Vec<u8>),
-	/// IPFS CID. The CID is stored on-chain.
-	/// The actual data is stored off-chain.
-	IPFS(Vec<u8>),
-	/// HTTP URL. The URL is stored on-chain.
-	/// The actual data is stored off-chain.
-	/// The URL is expected to be accessible via HTTP GET.
-	HTTP(Vec<u8>),
-}
-
-impl<AccountId> JobType<AccountId> {
+impl<AccountId, MaxParticipants: Get<u32> + Clone, MaxSubmissionLen: Get<u32>>
+	JobType<AccountId, MaxParticipants, MaxSubmissionLen>
+{
 	/// Checks if the job type is a phase one job.
 	pub fn is_phase_one(&self) -> bool {
 		use crate::jobs::JobType::*;
@@ -125,7 +130,7 @@ impl<AccountId> JobType<AccountId> {
 	}
 
 	/// Gets the participants for the job type, if applicable.
-	pub fn get_participants(self) -> Option<Vec<AccountId>> {
+	pub fn get_participants(self) -> Option<BoundedVec<AccountId, MaxParticipants>> {
 		use crate::jobs::JobType::*;
 		match self {
 			DKGTSSPhaseOne(info) => Some(info.participants),
@@ -201,27 +206,54 @@ pub enum JobState {
 }
 
 /// Represents a job submission with specified `AccountId` and `BlockNumber`.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct PhaseResult<AccountId, BlockNumber> {
+pub struct PhaseResult<
+	AccountId,
+	BlockNumber,
+	MaxParticipants: Get<u32> + Clone,
+	MaxKeyLen: Get<u32>,
+	MaxDataLen: Get<u32>,
+	MaxSignatureLen: Get<u32>,
+	MaxSubmissionLen: Get<u32>,
+	MaxProofLen: Get<u32>,
+> {
 	/// The owner's account ID.
 	pub owner: AccountId,
 	/// The type of the job submission.
-	pub result: JobResult,
+	pub result: JobResult<MaxParticipants, MaxKeyLen, MaxSignatureLen, MaxDataLen, MaxProofLen>,
 	/// The time-to-live (TTL) for the job, which determines the maximum allowed time for this job
 	/// to be available. After the TTL expires, the job can no longer be used.
 	pub ttl: BlockNumber,
 	/// permitted caller to use this result
 	pub permitted_caller: Option<AccountId>,
 	/// The type of the job submission.
-	pub job_type: JobType<AccountId>,
+	pub job_type: JobType<AccountId, MaxParticipants, MaxSubmissionLen>,
 }
 
-impl<AccountId, BlockNumber> PhaseResult<AccountId, BlockNumber>
-where
+impl<
+		AccountId,
+		BlockNumber,
+		MaxParticipants: Get<u32> + Clone,
+		MaxKeyLen: Get<u32>,
+		MaxDataLen: Get<u32>,
+		MaxSignatureLen: Get<u32>,
+		MaxSubmissionLen: Get<u32>,
+		MaxProofLen: Get<u32>,
+	>
+	PhaseResult<
+		AccountId,
+		BlockNumber,
+		MaxParticipants,
+		MaxKeyLen,
+		MaxDataLen,
+		MaxSignatureLen,
+		MaxSubmissionLen,
+		MaxProofLen,
+	> where
 	AccountId: Clone,
 {
-	pub fn participants(&self) -> Option<Vec<AccountId>> {
+	pub fn participants(&self) -> Option<BoundedVec<AccountId, MaxParticipants>> {
 		match &self.job_type {
 			JobType::DKGTSSPhaseOne(x) => Some(x.participants.clone()),
 			JobType::ZkSaaSPhaseOne(x) => Some(x.participants.clone()),
@@ -249,12 +281,17 @@ pub enum ValidatorOffence {
 
 #[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct RpcResponseJobsData<AccountId, BlockNumber> {
+pub struct RpcResponseJobsData<
+	AccountId,
+	BlockNumber,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+> {
 	/// The job id of the job
 	pub job_id: JobId,
 
 	/// The type of the job submission.
-	pub job_type: JobType<AccountId>,
+	pub job_type: JobType<AccountId, MaxParticipants, MaxSubmissionLen>,
 
 	/// Represents the maximum allowed submission time for a job result.
 	/// Once this time has passed, the result cannot be submitted.
@@ -265,15 +302,21 @@ pub struct RpcResponseJobsData<AccountId, BlockNumber> {
 	pub ttl: BlockNumber,
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum JobResult {
-	DKGPhaseOne(DKGTSSKeySubmissionResult),
-	DKGPhaseTwo(DKGTSSSignatureResult),
+pub enum JobResult<
+	MaxParticipants: Get<u32>,
+	MaxKeyLen: Get<u32>,
+	MaxSignatureLen: Get<u32>,
+	MaxDataLen: Get<u32>,
+	MaxProofLen: Get<u32>,
+> {
+	DKGPhaseOne(DKGTSSKeySubmissionResult<MaxKeyLen, MaxParticipants, MaxSignatureLen>),
+	DKGPhaseTwo(DKGTSSSignatureResult<MaxDataLen, MaxKeyLen, MaxSignatureLen>),
 	DKGPhaseThree(DKGTSSKeyRefreshResult),
-	DKGPhaseFour(DKGTSSKeyRotationResult),
-	ZkSaaSPhaseOne(ZkSaaSCircuitResult),
-	ZkSaaSPhaseTwo(ZkSaaSProofResult),
+	DKGPhaseFour(DKGTSSKeyRotationResult<MaxKeyLen, MaxSignatureLen>),
+	ZkSaaSPhaseOne(ZkSaaSCircuitResult<MaxParticipants>),
+	ZkSaaSPhaseTwo(ZkSaaSProofResult<MaxProofLen>),
 }
 
 /// Represents different types of validator offences.

--- a/primitives/src/jobs/traits.rs
+++ b/primitives/src/jobs/traits.rs
@@ -19,11 +19,17 @@ use crate::{
 	roles::RoleType,
 };
 use sp_arithmetic::traits::{BaseArithmetic, Unsigned};
-use sp_runtime::DispatchResult;
+use sp_runtime::{traits::Get, DispatchResult};
 use sp_std::vec::Vec;
 
 /// A trait that describes the job to fee calculation.
-pub trait JobToFee<AccountId, BlockNumber> {
+pub trait JobToFee<
+	AccountId,
+	BlockNumber,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+>
+{
 	/// The type that is returned as result from calculation.
 	type Balance: BaseArithmetic + From<u32> + Copy + Unsigned;
 
@@ -37,11 +43,24 @@ pub trait JobToFee<AccountId, BlockNumber> {
 	/// # Returns
 	///
 	/// Returns the calculated fee as `Self::Balance`.
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Self::Balance;
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Self::Balance;
 }
 
 /// A trait that describes the job result verification.
-pub trait MPCHandler<AccountId, BlockNumber, Balance> {
+pub trait MPCHandler<
+	AccountId,
+	BlockNumber,
+	Balance,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+	MaxKeyLen: Get<u32>,
+	MaxDataLen: Get<u32>,
+	MaxSignatureLen: Get<u32>,
+	MaxProofLen: Get<u32>,
+>
+{
 	/// Verifies the result of a job.
 	///
 	/// # Parameters
@@ -51,7 +70,17 @@ pub trait MPCHandler<AccountId, BlockNumber, Balance> {
 	/// # Errors
 	///
 	/// Returns a `DispatchResult` indicating success or an error if verification fails.
-	fn verify(data: JobWithResult<AccountId>) -> DispatchResult;
+	fn verify(
+		data: JobWithResult<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		>,
+	) -> DispatchResult;
 
 	// Verify a validator report
 	///

--- a/primitives/src/jobs/zksaas.rs
+++ b/primitives/src/jobs/zksaas.rs
@@ -14,121 +14,139 @@
 // You should have received a copy of the GNU General Public License
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-	jobs::{HyperData, JobId},
-	roles::ZeroKnowledgeRoleType,
-};
+use crate::{jobs::JobId, roles::ZeroKnowledgeRoleType};
 use frame_support::pallet_prelude::*;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::{ecdsa, RuntimeDebug};
-use sp_std::vec::Vec;
+use sp_runtime::traits::Get;
+
+/// Enum representing different types of data sources.
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
+#[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
+pub enum HyperData<MaxSubmissionLen: Get<u32>> {
+	/// Raw data, stored on-chain.
+	///
+	/// Only use this for small files.
+	Raw(BoundedVec<u8, MaxSubmissionLen>),
+	/// IPFS CID. The CID is stored on-chain.
+	/// The actual data is stored off-chain.
+	IPFS(BoundedVec<u8, MaxSubmissionLen>),
+	/// HTTP URL. The URL is stored on-chain.
+	/// The actual data is stored off-chain.
+	/// The URL is expected to be accessible via HTTP GET.
+	HTTP(BoundedVec<u8, MaxSubmissionLen>),
+}
 
 /// Enum representing different types of circuits and snark schemes.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum ZkSaaSSystem {
-	Groth16(Groth16System),
+pub enum ZkSaaSSystem<MaxSubmissionLen: Get<u32>> {
+	Groth16(Groth16System<MaxSubmissionLen>),
 }
 
 /// Represents the Groth16 system for zk-SNARKs.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct Groth16System {
+pub struct Groth16System<MaxSubmissionLen: Get<u32>> {
 	/// R1CS circuit file.
-	pub circuit: HyperData,
+	pub circuit: HyperData<MaxSubmissionLen>,
 	/// Number of inputs
 	pub num_inputs: u64,
 	/// Number of constraints
 	pub num_constraints: u64,
 	/// Proving key file.
-	pub proving_key: HyperData,
+	pub proving_key: HyperData<MaxSubmissionLen>,
 	/// Verifying key bytes
-	pub verifying_key: Vec<u8>,
+	pub verifying_key: BoundedVec<u8, MaxSubmissionLen>,
 	/// Circom WASM file.
-	pub wasm: HyperData,
+	pub wasm: HyperData<MaxSubmissionLen>,
 }
 
 /// Represents the (zk-SNARK) Phase One job type.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ZkSaaSPhaseOneJobType<AccountId> {
+pub struct ZkSaaSPhaseOneJobType<
+	AccountId,
+	MaxParticipants: Get<u32> + Clone,
+	MaxSubmissionLen: Get<u32>,
+> {
 	/// List of participants' account IDs.
-	pub participants: Vec<AccountId>,
+	pub participants: BoundedVec<AccountId, MaxParticipants>,
 	/// the caller permitted to use this result later
 	pub permitted_caller: Option<AccountId>,
 	/// ZK-SNARK Proving system
-	pub system: ZkSaaSSystem,
+	pub system: ZkSaaSSystem<MaxSubmissionLen>,
 	/// The role type of the job
 	pub role_type: ZeroKnowledgeRoleType,
 }
 
 /// Represents the (zk-SNARK) Phase Two job type.
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ZkSaaSPhaseTwoJobType {
+pub struct ZkSaaSPhaseTwoJobType<MaxSubmissionLen: Get<u32>> {
 	/// The phase one ID.
 	pub phase_one_id: JobId,
 	/// ZK-SNARK Proving request
-	pub request: ZkSaaSPhaseTwoRequest,
+	pub request: ZkSaaSPhaseTwoRequest<MaxSubmissionLen>,
 	/// The role type of the job
 	pub role_type: ZeroKnowledgeRoleType,
 }
 
 /// Represents ZK-SNARK proving request
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum ZkSaaSPhaseTwoRequest {
+pub enum ZkSaaSPhaseTwoRequest<MaxSubmissionLen: Get<u32>> {
 	/// Groth16 proving request
-	Groth16(Groth16ProveRequest),
+	Groth16(Groth16ProveRequest<MaxSubmissionLen>),
 }
 
 /// Represents Groth16 proving request
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct Groth16ProveRequest {
+pub struct Groth16ProveRequest<MaxSubmissionLen: Get<u32>> {
 	/// Public input that are used during the verification
-	pub public_input: Vec<u8>,
+	pub public_input: BoundedVec<u8, MaxSubmissionLen>,
 	/// `a` is the full assignment (full_assginment[0] is 1)
 	/// a = full_assginment[1..]
 	/// Each element contains a PSS of the witness
-	pub a_shares: Vec<HyperData>,
+	pub a_shares: BoundedVec<HyperData<MaxSubmissionLen>, MaxSubmissionLen>,
 	/// `ax` is the auxiliary input
 	/// ax = full_assginment[num_inputs..]
 	/// Each element contains a PSS of the auxiliary input
-	pub ax_shares: Vec<HyperData>,
+	pub ax_shares: BoundedVec<HyperData<MaxSubmissionLen>, MaxSubmissionLen>,
 	/// PSS of the QAP polynomials
-	pub qap_shares: Vec<QAPShare>,
+	pub qap_shares: BoundedVec<QAPShare<MaxSubmissionLen>, MaxSubmissionLen>,
 }
 
 /// Represents QAP share
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct QAPShare {
-	pub a: HyperData,
-	pub b: HyperData,
-	pub c: HyperData,
+pub struct QAPShare<MaxSubmissionLen: Get<u32>> {
+	pub a: HyperData<MaxSubmissionLen>,
+	pub b: HyperData<MaxSubmissionLen>,
+	pub c: HyperData<MaxSubmissionLen>,
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ZkSaaSCircuitResult {
+pub struct ZkSaaSCircuitResult<MaxParticipants: Get<u32>> {
 	/// The job id of the job (circuit)
 	pub job_id: JobId,
 
 	/// List of participants' public keys
-	pub participants: Vec<ecdsa::Public>,
+	pub participants: BoundedVec<ecdsa::Public, MaxParticipants>,
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum ZkSaaSProofResult {
-	Arkworks(ArkworksProofResult),
-	Circom(CircomProofResult),
+pub enum ZkSaaSProofResult<MaxProofLen: Get<u32>> {
+	Arkworks(ArkworksProofResult<MaxProofLen>),
+	Circom(CircomProofResult<MaxProofLen>),
 }
 
-impl ZkSaaSProofResult {
-	pub fn proof(&self) -> Vec<u8> {
+impl<MaxProofLen: Get<u32>> ZkSaaSProofResult<MaxProofLen> {
+	pub fn proof(&self) -> BoundedVec<u8, MaxProofLen> {
 		match self {
 			ZkSaaSProofResult::Arkworks(x) => x.proof.clone(),
 			ZkSaaSProofResult::Circom(x) => x.proof.clone(),
@@ -136,14 +154,14 @@ impl ZkSaaSProofResult {
 	}
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct CircomProofResult {
-	pub proof: Vec<u8>,
+pub struct CircomProofResult<MaxProofLen: Get<u32>> {
+	pub proof: BoundedVec<u8, MaxProofLen>,
 }
 
-#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone)]
+#[derive(PartialEq, Eq, Encode, Decode, RuntimeDebug, TypeInfo, Clone, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ArkworksProofResult {
-	pub proof: Vec<u8>,
+pub struct ArkworksProofResult<MaxProofLen: Get<u32>> {
+	pub proof: BoundedVec<u8, MaxProofLen>,
 }

--- a/primitives/src/roles/mod.rs
+++ b/primitives/src/roles/mod.rs
@@ -20,7 +20,7 @@ use frame_support::pallet_prelude::*;
 use parity_scale_codec::alloc::string::ToString;
 use scale_info::prelude::string::String;
 use sp_arithmetic::Percent;
-use sp_std::{ops::Add, vec::Vec};
+use sp_std::ops::Add;
 
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
@@ -33,7 +33,9 @@ pub use tss::*;
 pub use zksaas::*;
 
 /// Role type to be used in the system.
-#[derive(Encode, Decode, Copy, Clone, Debug, PartialEq, Eq, TypeInfo, PartialOrd, Ord)]
+#[derive(
+	Encode, Decode, Copy, Clone, Debug, PartialEq, Eq, TypeInfo, PartialOrd, Ord, MaxEncodedLen,
+)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum RoleType {
 	/// TSS role type.
@@ -111,15 +113,15 @@ impl RoleType {
 }
 
 /// Metadata associated with a role type.
-#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo)]
+#[derive(Encode, Decode, Clone, Debug, PartialEq, Eq, TypeInfo, MaxEncodedLen)]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub enum RoleTypeMetadata {
-	Tss(TssRoleMetadata),
-	ZkSaas(ZkSaasRoleMetadata),
+pub enum RoleTypeMetadata<MaxAuthorityKeyLen: Get<u32>> {
+	Tss(TssRoleMetadata<MaxAuthorityKeyLen>),
+	ZkSaas(ZkSaasRoleMetadata<MaxAuthorityKeyLen>),
 	LightClientRelaying,
 }
 
-impl RoleTypeMetadata {
+impl<MaxAuthorityKeyLen: Get<u32>> RoleTypeMetadata<MaxAuthorityKeyLen> {
 	/// Return type of role.
 	pub fn get_role_type(&self) -> RoleType {
 		match self {
@@ -129,11 +131,11 @@ impl RoleTypeMetadata {
 		}
 	}
 
-	pub fn get_authority_key(&self) -> Vec<u8> {
+	pub fn get_authority_key(&self) -> BoundedVec<u8, MaxAuthorityKeyLen> {
 		match self {
 			RoleTypeMetadata::Tss(metadata) => metadata.authority_key.clone(),
 			RoleTypeMetadata::ZkSaas(metadata) => metadata.authority_key.clone(),
-			_ => Vec::new(),
+			_ => Default::default(),
 		}
 	}
 }

--- a/primitives/src/roles/tss.rs
+++ b/primitives/src/roles/tss.rs
@@ -18,14 +18,25 @@ use frame_support::pallet_prelude::*;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
-use sp_std::vec::Vec;
+use sp_runtime::traits::Get;
 
 /// Threshold signature role types and their specific elliptic curve.
 ///
 /// Naming convention:
 /// <vendor><protocol><curve>
 #[derive(
-	Encode, Decode, Copy, Clone, RuntimeDebug, PartialEq, Default, Eq, TypeInfo, PartialOrd, Ord,
+	Encode,
+	Decode,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Default,
+	Eq,
+	TypeInfo,
+	PartialOrd,
+	Ord,
+	MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 #[repr(u16)]
@@ -48,10 +59,10 @@ pub enum ThresholdSignatureRoleType {
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Default, Eq, TypeInfo, PartialOrd, Ord,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct TssRoleMetadata {
+pub struct TssRoleMetadata<MaxAuthorityKeyLen: Get<u32>> {
 	/// The threshold role type for the DKG.
 	pub role_type: ThresholdSignatureRoleType,
 
 	/// The authority key associated with the role.
-	pub authority_key: Vec<u8>,
+	pub authority_key: BoundedVec<u8, MaxAuthorityKeyLen>,
 }

--- a/primitives/src/roles/zksaas.rs
+++ b/primitives/src/roles/zksaas.rs
@@ -18,10 +18,21 @@ use frame_support::pallet_prelude::*;
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 use sp_core::RuntimeDebug;
-use sp_std::vec::Vec;
+use sp_runtime::traits::Get;
 
 #[derive(
-	Encode, Decode, Copy, Clone, RuntimeDebug, PartialEq, Default, Eq, TypeInfo, PartialOrd, Ord,
+	Encode,
+	Decode,
+	Copy,
+	Clone,
+	RuntimeDebug,
+	PartialEq,
+	Default,
+	Eq,
+	TypeInfo,
+	PartialOrd,
+	Ord,
+	MaxEncodedLen,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
 pub enum ZeroKnowledgeRoleType {
@@ -35,11 +46,11 @@ pub enum ZeroKnowledgeRoleType {
 	Encode, Decode, Clone, RuntimeDebug, PartialEq, Default, Eq, TypeInfo, PartialOrd, Ord,
 )]
 #[cfg_attr(feature = "std", derive(Serialize, Deserialize))]
-pub struct ZkSaasRoleMetadata {
+pub struct ZkSaasRoleMetadata<MaxAuthorityKeyLen: Get<u32>> {
 	/// The zkSaaS scheme
 	pub role_type: ZeroKnowledgeRoleType,
 
 	/// The authority key associated with the role.
 	// TODO: Expand this
-	pub authority_key: Vec<u8>,
+	pub authority_key: BoundedVec<u8, MaxAuthorityKeyLen>,
 }

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -46,6 +46,7 @@ use pallet_transaction_payment::{
 	CurrencyAdapter, FeeDetails, Multiplier, RuntimeDispatchInfo, TargetedFeeAdjustment,
 };
 use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
@@ -1070,8 +1071,30 @@ impl pallet_airdrop_claims::Config for Runtime {
 
 pub struct MockMPCHandler;
 
-impl MPCHandler<AccountId, BlockNumber, Balance> for MockMPCHandler {
-	fn verify(_data: JobWithResult<AccountId>) -> DispatchResult {
+impl
+	MPCHandler<
+		AccountId,
+		BlockNumber,
+		Balance,
+		MaxParticipants,
+		MaxSubmissionLen,
+		MaxKeyLen,
+		MaxDataLen,
+		MaxSignatureLen,
+		MaxProofLen,
+	> for MockMPCHandler
+{
+	fn verify(
+		_data: JobWithResult<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		>,
+	) -> DispatchResult {
 		Ok(())
 	}
 
@@ -1112,26 +1135,45 @@ impl pallet_roles::Config for Runtime {
 	type JobsHandler = Jobs;
 	type RoleKeyId = RoleKeyId;
 	type MaxRolesPerAccount = ConstU32<2>;
-	type MPCHandler = MockMPCHandler;
 	type InflationRewardPerSession = InflationRewardPerSession;
 	type ValidatorSet = Historical;
 	type ReportOffences = OffenceHandler;
 	type ValidatorRewardDistribution = Reward;
+	type MaxRolesPerValidator = MaxRolesPerValidator;
+	type MaxKeyLen = MaxKeyLen;
 	type WeightInfo = ();
 }
 
 pub struct MockJobToFeeHandler;
 
-impl JobToFee<AccountId, BlockNumber> for MockJobToFeeHandler {
+impl JobToFee<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen> for MockJobToFeeHandler {
 	type Balance = Balance;
 
-	fn job_to_fee(_job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		_job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		Default::default()
 	}
 }
 
 parameter_types! {
 	pub const JobsPalletId: PalletId = PalletId(*b"py/jobss");
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxParticipants: u32 = 10;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSubmissionLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxKeyLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxDataLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxSignatureLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxProofLen: u32 = 256;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxActiveJobsPerValidator: u32 = 100;
+	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
+	pub const MaxRolesPerValidator: u32 = 100;
 }
 
 impl pallet_jobs::Config for Runtime {
@@ -1142,6 +1184,13 @@ impl pallet_jobs::Config for Runtime {
 	type RolesHandler = Roles;
 	type MPCHandler = MockMPCHandler;
 	type PalletId = JobsPalletId;
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
+	type MaxActiveJobsPerValidator = MaxActiveJobsPerValidator;
 	type WeightInfo = ();
 }
 

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -46,6 +46,7 @@ use pallet_transaction_payment::{
 	CurrencyAdapter, FeeDetails, Multiplier, RuntimeDispatchInfo, TargetedFeeAdjustment,
 };
 use parity_scale_codec::{Decode, Encode};
+use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_api::impl_runtime_apis;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata, H160, H256, U256};
@@ -60,7 +61,7 @@ use sp_runtime::{
 	transaction_validity::{
 		TransactionPriority, TransactionSource, TransactionValidity, TransactionValidityError,
 	},
-	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, FixedU128, Perquintill,
+	ApplyExtrinsicResult, DispatchResult, FixedPointNumber, FixedU128, Perquintill, RuntimeDebug,
 	SaturatedConversion,
 };
 use sp_std::prelude::*;
@@ -1075,16 +1076,14 @@ impl pallet_airdrop_claims::Config for Runtime {
 	type WeightInfo = ();
 }
 
-parameter_types! {
-	pub const JobsPalletId: PalletId = PalletId(*b"py/jobss");
-}
-
 pub struct MockJobToFeeHandler;
 
-impl JobToFee<AccountId, BlockNumber> for MockJobToFeeHandler {
+impl JobToFee<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen> for MockJobToFeeHandler {
 	type Balance = Balance;
 
-	fn job_to_fee(job: &JobSubmission<AccountId, BlockNumber>) -> Balance {
+	fn job_to_fee(
+		job: &JobSubmission<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen>,
+	) -> Balance {
 		match job.job_type {
 			JobType::DKGTSSPhaseOne(_) |
 			JobType::DKGTSSPhaseTwo(_) |
@@ -1097,8 +1096,30 @@ impl JobToFee<AccountId, BlockNumber> for MockJobToFeeHandler {
 
 pub struct MockMPCHandler;
 
-impl MPCHandler<AccountId, BlockNumber, Balance> for MockMPCHandler {
-	fn verify(data: JobWithResult<AccountId>) -> DispatchResult {
+impl
+	MPCHandler<
+		AccountId,
+		BlockNumber,
+		Balance,
+		MaxParticipants,
+		MaxSubmissionLen,
+		MaxKeyLen,
+		MaxDataLen,
+		MaxSignatureLen,
+		MaxProofLen,
+	> for MockMPCHandler
+{
+	fn verify(
+		data: JobWithResult<
+			AccountId,
+			MaxParticipants,
+			MaxSubmissionLen,
+			MaxKeyLen,
+			MaxDataLen,
+			MaxSignatureLen,
+			MaxProofLen,
+		>,
+	) -> DispatchResult {
 		match data.result {
 			JobResult::DKGPhaseOne(_) |
 			JobResult::DKGPhaseTwo(_) |
@@ -1121,6 +1142,34 @@ impl MPCHandler<AccountId, BlockNumber, Balance> for MockMPCHandler {
 	}
 }
 
+parameter_types! {
+	pub const JobsPalletId: PalletId = PalletId(*b"py/jobss");
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxParticipants: u32 = 10;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxSubmissionLen: u32 = 256;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxKeyLen: u32 = 256;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxDataLen: u32 = 256;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxSignatureLen: u32 = 256;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxProofLen: u32 = 256;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxActiveJobsPerValidator: u32 = 100;
+	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
+	#[derive(Serialize, Deserialize)]
+	pub const MaxRolesPerValidator: u32 = 100;
+}
+
 impl pallet_jobs::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ForceOrigin = EnsureRootOrHalfCouncil;
@@ -1129,6 +1178,13 @@ impl pallet_jobs::Config for Runtime {
 	type RolesHandler = Roles;
 	type MPCHandler = MockMPCHandler;
 	type PalletId = JobsPalletId;
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
+	type MaxActiveJobsPerValidator = MaxActiveJobsPerValidator;
 	type WeightInfo = ();
 }
 
@@ -1156,11 +1212,12 @@ impl pallet_roles::Config for Runtime {
 	type JobsHandler = Jobs;
 	type RoleKeyId = RoleKeyId;
 	type MaxRolesPerAccount = ConstU32<2>;
-	type MPCHandler = MockMPCHandler;
 	type InflationRewardPerSession = InflationRewardPerSession;
 	type ValidatorSet = Historical;
 	type ReportOffences = OffenceHandler;
 	type ValidatorRewardDistribution = Reward;
+	type MaxRolesPerValidator = MaxRolesPerValidator;
+	type MaxKeyLen = MaxKeyLen;
 	type WeightInfo = ();
 }
 
@@ -1168,6 +1225,12 @@ impl pallet_dkg::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
 	type UpdateOrigin = EnsureRootOrHalfCouncil;
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
 	type WeightInfo = ();
 }
 
@@ -1176,6 +1239,12 @@ impl pallet_zksaas::Config for Runtime {
 	type Currency = Balances;
 	type UpdateOrigin = EnsureRootOrHalfCouncil;
 	type Verifier = (ArkworksVerifierGroth16Bn254, CircomVerifierGroth16Bn254);
+	type MaxParticipants = MaxParticipants;
+	type MaxSubmissionLen = MaxSubmissionLen;
+	type MaxKeyLen = MaxKeyLen;
+	type MaxDataLen = MaxDataLen;
+	type MaxSignatureLen = MaxSignatureLen;
+	type MaxProofLen = MaxProofLen;
 	type WeightInfo = ();
 }
 
@@ -1426,18 +1495,18 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_jobs_rpc_runtime_api::JobsApi<Block, AccountId> for Runtime {
+	impl pallet_jobs_rpc_runtime_api::JobsApi<Block, AccountId, MaxParticipants, MaxSubmissionLen, MaxKeyLen, MaxDataLen, MaxSignatureLen, MaxProofLen> for Runtime {
 		fn query_jobs_by_validator(
 			validator: AccountId,
-		) -> Option<Vec<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>>> {
+		) -> Option<Vec<RpcResponseJobsData<AccountId, BlockNumberOf<Block>, MaxParticipants, MaxSubmissionLen>>> {
 			Jobs::query_jobs_by_validator(validator)
 		}
 
-		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId, BlockNumberOf<Block>>> {
+		fn query_job_by_id(role_type: RoleType, job_id: JobId) -> Option<RpcResponseJobsData<AccountId, BlockNumberOf<Block>, MaxParticipants, MaxSubmissionLen>> {
 			Jobs::query_job_by_id(role_type, job_id)
 		}
 
-		fn query_job_result(role_type: RoleType, job_id: JobId) -> Option<PhaseResult<AccountId, BlockNumberOf<Block>>> {
+		fn query_job_result(role_type: RoleType, job_id: JobId) -> Option<PhaseResult<AccountId, BlockNumberOf<Block>, MaxParticipants, MaxKeyLen, MaxDataLen, MaxSignatureLen, MaxSubmissionLen, MaxProofLen>> {
 			Jobs::query_job_result(role_type, job_id)
 		}
 


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Make all types in jobs/roles pallets bounded
- Remove `without_storage_info` from jobs/roles pallet

