### PR TITLE
fix: Roles pallet - rename validators to restakers

### DIFF
--- a/pallets/dkg/src/mock.rs
+++ b/pallets/dkg/src/mock.rs
@@ -80,7 +80,7 @@ parameter_types! {
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxParticipants: u32 = 10;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = 32;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxKeyLen: u32 = 256;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]

--- a/pallets/jobs/src/lib.rs
+++ b/pallets/jobs/src/lib.rs
@@ -272,7 +272,7 @@ pub mod module {
 
 				for participant in participants {
 					ensure!(
-						T::RolesHandler::is_validator(participant.clone(), role_type),
+						T::RolesHandler::is_restaker(participant.clone(), role_type),
 						Error::<T>::InvalidValidator
 					);
 
@@ -299,7 +299,7 @@ pub mod module {
 				let participants = result.participants().ok_or(Error::<T>::InvalidJobPhase)?;
 				for participant in participants {
 					ensure!(
-						T::RolesHandler::is_validator(participant.clone(), role_type),
+						T::RolesHandler::is_restaker(participant.clone(), role_type),
 						Error::<T>::InvalidValidator
 					);
 

--- a/pallets/jobs/src/mock.rs
+++ b/pallets/jobs/src/mock.rs
@@ -346,7 +346,7 @@ parameter_types! {
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxParticipants: u32 = 10;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = 32;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxKeyLen: u32 = 256;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]

--- a/pallets/jobs/src/mock.rs
+++ b/pallets/jobs/src/mock.rs
@@ -322,6 +322,7 @@ impl pallet_staking::Config for Runtime {
 
 parameter_types! {
 	pub InflationRewardPerSession: Balance = 10_000;
+	pub MaxRestake : Percent = Percent::from_percent(50);
 	pub Reward : ValidatorRewardDistribution = ValidatorRewardDistribution::try_new(Percent::from_rational(1_u32,2_u32), Percent::from_rational(1_u32,2_u32)).unwrap();
 }
 
@@ -335,6 +336,7 @@ impl pallet_roles::Config for Runtime {
 	type ValidatorSet = Historical;
 	type ReportOffences = OffenceHandler;
 	type MaxKeyLen = MaxKeyLen;
+	type MaxRestake = MaxRestake;
 	type MaxRolesPerValidator = MaxActiveJobsPerValidator;
 	type WeightInfo = ();
 }

--- a/pallets/roles/src/benchmarking.rs
+++ b/pallets/roles/src/benchmarking.rs
@@ -112,7 +112,7 @@ mod benchmarks {
 	fn update_profile() {
 		let caller: T::AccountId = create_validator_account::<T>("Alice");
 		let shared_profile = shared_profile::<T>();
-		let ledger = RoleStakingLedger::<T>::new(caller.clone(), shared_profile.clone(), vec![]);
+		let ledger = RestakingLedger::<T>::new(caller.clone(), shared_profile.clone(), vec![]);
 		Ledger::<T>::insert(caller.clone(), ledger);
 		// Updating shared stake from 3000 to 5000 tokens
 		let updated_profile = updated_profile::<T>();
@@ -129,7 +129,7 @@ mod benchmarks {
 	fn delete_profile() {
 		let caller: T::AccountId = create_validator_account::<T>("Alice");
 		let shared_profile = shared_profile::<T>();
-		let ledger = RoleStakingLedger::<T>::new(caller.clone(), shared_profile.clone(), vec![]);
+		let ledger = RestakingLedger::<T>::new(caller.clone(), shared_profile.clone(), vec![]);
 		Ledger::<T>::insert(caller.clone(), ledger);
 
 		#[extrinsic_call]

--- a/pallets/roles/src/mock.rs
+++ b/pallets/roles/src/mock.rs
@@ -348,6 +348,7 @@ impl pallet_jobs::Config for Runtime {
 
 parameter_types! {
 	pub InflationRewardPerSession: Balance = 10_000;
+	pub MaxRestake: Percent = Percent::from_percent(50);
 	pub Reward : ValidatorRewardDistribution = ValidatorRewardDistribution::try_new(Percent::from_rational(1_u32,2_u32), Percent::from_rational(1_u32,2_u32)).unwrap();
 }
 
@@ -362,6 +363,7 @@ impl Config for Runtime {
 	type ReportOffences = OffenceHandler;
 	type MaxRolesPerValidator = MaxRolesPerValidator;
 	type MaxKeyLen = MaxKeyLen;
+	type MaxRestake = MaxRestake;
 	type WeightInfo = ();
 }
 

--- a/pallets/roles/src/mock.rs
+++ b/pallets/roles/src/mock.rs
@@ -312,7 +312,7 @@ parameter_types! {
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxParticipants: u32 = 10;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = 32;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxKeyLen: u32 = 256;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]

--- a/pallets/roles/src/tests.rs
+++ b/pallets/roles/src/tests.rs
@@ -21,7 +21,7 @@ use mock::*;
 use profile::{IndependentRestakeProfile, Record, SharedRestakeProfile};
 use sp_std::{default::Default, vec};
 use tangle_primitives::{
-	jobs::ReportValidatorOffence,
+	jobs::ReportRestakerOffence,
 	roles::{ThresholdSignatureRoleType, ZeroKnowledgeRoleType},
 };
 
@@ -350,7 +350,7 @@ fn test_report_offence_should_work() {
 		let session_index = pallet_session::CurrentIndex::<Runtime>::get();
 
 		// Create offence report.
-		let offence_report = ReportValidatorOffence {
+		let offence_report = ReportRestakerOffence {
 			session_index,
 			validator_set_count: 4,
 			role_type: RoleType::Tss(Default::default()),

--- a/precompiles/jobs/src/mock.rs
+++ b/precompiles/jobs/src/mock.rs
@@ -277,7 +277,7 @@ parameter_types! {
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxParticipants: u32 = 10;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = 32;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]
 	pub const MaxKeyLen: u32 = 256;
 	#[derive(Clone, Debug, Eq, PartialEq, TypeInfo)]

--- a/precompiles/jobs/src/mock.rs
+++ b/precompiles/jobs/src/mock.rs
@@ -202,7 +202,7 @@ impl JobToFee<AccountId, BlockNumber, MaxParticipants, MaxSubmissionLen> for Moc
 pub struct MockRolesHandler;
 
 impl RolesHandler<AccountId> for MockRolesHandler {
-	fn is_validator(address: AccountId, _role_type: RoleType) -> bool {
+	fn is_restaker(address: AccountId, _role_type: RoleType) -> bool {
 		let validators = [
 			AccountId::from_u64(1u64),
 			AccountId::from_u64(2u64),
@@ -217,7 +217,7 @@ impl RolesHandler<AccountId> for MockRolesHandler {
 		None
 	}
 
-	fn report_offence(_offence_report: ReportValidatorOffence<AccountId>) -> DispatchResult {
+	fn report_offence(_offence_report: ReportRestakerOffence<AccountId>) -> DispatchResult {
 		Ok(())
 	}
 }

--- a/precompiles/staking/src/lib.rs
+++ b/precompiles/staking/src/lib.rs
@@ -189,13 +189,13 @@ where
 	}
 
 	#[precompile::public("isValidator(address)")]
-	#[precompile::public("is_validator(address)")]
+	#[precompile::public("is_restaker(address)")]
 	#[precompile::view]
-	fn is_validator(handle: &mut impl PrecompileHandle, validator: Address) -> EvmResult<bool> {
+	fn is_restaker(handle: &mut impl PrecompileHandle, validator: Address) -> EvmResult<bool> {
 		let validator_account = Runtime::AddressMapping::into_account_id(validator.0);
 		handle.record_cost(RuntimeHelper::<Runtime>::db_read_gas_cost())?;
-		let is_validator = pallet_staking::Validators::<Runtime>::contains_key(validator_account);
-		Ok(is_validator)
+		let is_restaker = pallet_staking::Validators::<Runtime>::contains_key(validator_account);
+		Ok(is_restaker)
 	}
 
 	#[precompile::public("maxNominatorCount()")]

--- a/precompiles/staking/src/tests.rs
+++ b/precompiles/staking/src/tests.rs
@@ -90,7 +90,7 @@ fn is_validator_works() {
 			.prepare_test(
 				TestAccount::Alex,
 				H160::from_low_u64_be(1),
-				PCall::is_validator { validator: H160::from(TestAccount::Alex).into() },
+				PCall::is_restaker { validator: H160::from(TestAccount::Alex).into() },
 			)
 			.expect_cost(0)
 			.expect_no_logs()

--- a/primitives/src/jobs/mod.rs
+++ b/primitives/src/jobs/mod.rs
@@ -334,7 +334,7 @@ pub enum ValidatorOffenceType {
 
 /// An offence report that is filed if a validator misbehaves.
 #[derive(Clone, RuntimeDebug, TypeInfo, PartialEq, Eq)]
-pub struct ReportValidatorOffence<Offender> {
+pub struct ReportRestakerOffence<Offender> {
 	/// The current session index in which offence is reported.
 	pub session_index: u32,
 	/// The size of the validator set in current session/era.

--- a/primitives/src/roles/traits.rs
+++ b/primitives/src/roles/traits.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::jobs::ReportValidatorOffence;
+use crate::jobs::ReportRestakerOffence;
 use sp_runtime::DispatchResult;
 use sp_std::vec::Vec;
 
@@ -32,7 +32,7 @@ pub trait RolesHandler<AccountId> {
 	/// # Returns
 	///
 	/// Returns `true` if the validator is permitted to work with this job type, otherwise `false`.
-	fn is_validator(address: AccountId, role_type: RoleType) -> bool;
+	fn is_restaker(address: AccountId, role_type: RoleType) -> bool;
 
 	/// Report offence for the given validator.
 	/// This function will report validators for committing offence.
@@ -43,7 +43,7 @@ pub trait RolesHandler<AccountId> {
 	/// # Returns
 	///
 	/// Returns Ok() if validator offence report is submitted successfully.
-	fn report_offence(offence_report: ReportValidatorOffence<AccountId>) -> DispatchResult;
+	fn report_offence(offence_report: ReportRestakerOffence<AccountId>) -> DispatchResult;
 
 	/// Retrieves role key associated with given validator
 	///

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -1133,6 +1133,7 @@ impl ReportOffence<AccountId, IdTuple, Offence> for OffenceHandler {
 
 parameter_types! {
 	pub InflationRewardPerSession: Balance = 10_000;
+	pub MaxRestake: Percent = Percent::from_percent(50);
 	pub Reward : tangle_primitives::roles::ValidatorRewardDistribution = tangle_primitives::roles::ValidatorRewardDistribution::try_new(Percent::from_rational(1_u32,2_u32), Percent::from_rational(1_u32,2_u32)).unwrap();
 }
 
@@ -1147,6 +1148,7 @@ impl pallet_roles::Config for Runtime {
 	type ValidatorRewardDistribution = Reward;
 	type MaxRolesPerValidator = MaxRolesPerValidator;
 	type MaxKeyLen = MaxKeyLen;
+	type MaxRestake = MaxRestake;
 	type WeightInfo = ();
 }
 

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -1179,7 +1179,7 @@ parameter_types! {
 	pub const MaxParticipants: u32 = 10;
 	#[derive(Clone, Eq, PartialEq, TypeInfo, Encode, Decode, RuntimeDebug)]
 	#[derive(Serialize, Deserialize)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = 32;
 	#[derive(Clone, Eq, PartialEq, TypeInfo, Encode, Decode, RuntimeDebug)]
 	#[derive(Serialize, Deserialize)]
 	pub const MaxKeyLen: u32 = 256;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1228,6 +1228,7 @@ impl ReportOffence<AccountId, IdTuple, Offence> for OffenceHandler {
 
 parameter_types! {
 	pub InflationRewardPerSession: Balance = 10_000;
+	pub MaxRestake: Percent = Percent::from_percent(50);
 	pub Reward : ValidatorRewardDistribution = ValidatorRewardDistribution::try_new(Percent::from_rational(1_u32,2_u32), Percent::from_rational(1_u32,2_u32)).unwrap();
 }
 
@@ -1240,6 +1241,7 @@ impl pallet_roles::Config for Runtime {
 	type ValidatorSet = Historical;
 	type ReportOffences = OffenceHandler;
 	type ValidatorRewardDistribution = Reward;
+	type MaxRestake = MaxRestake;
 	type MaxRolesPerValidator = MaxRolesPerValidator;
 	type MaxKeyLen = MaxKeyLen;
 	type WeightInfo = ();

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1165,7 +1165,7 @@ parameter_types! {
 parameter_types! {
 	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
 	#[derive(Serialize, Deserialize)]
-	pub const MaxSubmissionLen: u32 = 256;
+	pub const MaxSubmissionLen: u32 = 32;
 }
 
 parameter_types! {

--- a/types/src/interfaces/lookup.ts
+++ b/types/src/interfaces/lookup.ts
@@ -4359,7 +4359,7 @@ export default {
     _enum: ['AlreadyInitialized', 'LightClientUpdateNotAllowed', 'BlockAlreadySubmitted', 'UnknownParentHeader', 'NotTrustedSigner', 'ValidateUpdatesParameterError', 'TrustlessModeError', 'InvalidSyncCommitteeBitsSum', 'SyncCommitteeBitsSumLessThanThreshold', 'InvalidNetworkConfig', 'InvalidBlsSignature', 'InvalidExecutionBlock', 'ActiveHeaderSlotLessThanFinalizedSlot', 'UpdateHeaderSlotLessThanFinalizedHeaderSlot', 'UpdateSignatureSlotLessThanAttestedHeaderSlot', 'InvalidUpdatePeriod', 'InvalidFinalityProof', 'InvalidExecutionBlockHashProof', 'NextSyncCommitteeNotPresent', 'InvalidNextSyncCommitteeProof', 'FinalizedExecutionHeaderNotPresent', 'FinalizedBeaconHeaderNotPresent', 'UnfinalizedHeaderNotPresent', 'SyncCommitteeUpdateNotPresent', 'HeaderHashDoesNotExist', 'BlockHashesDoNotMatch', 'InvalidSignaturePeriod', 'CurrentSyncCommitteeNotSet', 'NextSyncCommitteeNotSet', 'InvalidClientMode', 'HashesGcThresholdInsufficient', 'ChainCannotBeClosed']
   },
   /**
-   * Lookup645: pallet_roles::RoleStakingLedger<T>
+   * Lookup645: pallet_roles::RestakingLedger<T>
    **/
   PalletRolesRoleStakingLedger: {
     stash: 'AccountId32',


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Rename `validators` in roles pallet to `restakers` 
- Make `MaxRestake` runtime config

Part of #466, split to seperate PR for easier review
