### PR TITLE
Remove light client from mainnet runtime, update values

### DIFF
--- a/node/src/chainspec/mainnet.rs
+++ b/node/src/chainspec/mainnet.rs
@@ -302,18 +302,11 @@ fn mainnet_genesis(
 		ethereum: Default::default(),
 		dynamic_fee: Default::default(),
 		base_fee: Default::default(),
-		eth_2_client: Eth2ClientConfig {
-			networks: vec![(
-				webb_proposals::TypedChainId::Evm(1),
-				NetworkConfig::new(&Network::Mainnet),
-			)],
-			phantom: PhantomData,
-		},
 		claims: ClaimsConfig {
 			claims: genesis_airdrop.claims,
 			vesting: vesting_claims,
 			expiry: Some((
-				5_256_000u64,
+				525_600u64,
 				MultiAddress::Native(TreasuryPalletId::get().into_account_truncating()),
 			)),
 		},

--- a/pallets/transaction-pause/src/weights.rs
+++ b/pallets/transaction-pause/src/weights.rs
@@ -49,8 +49,8 @@ pub trait WeightInfo {
 }
 
 /// Weights for module_transaction_pause using the Acala node and recommended hardware.
-pub struct AcalaWeight<T>(PhantomData<T>);
-impl<T: frame_system::Config> WeightInfo for AcalaWeight<T> {
+pub struct SubstrateWeight<T>(PhantomData<T>);
+impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	fn pause_transaction() -> Weight {
 		Weight::from_parts(32_778_000, 0)
 			.saturating_add(T::DbWeight::get().reads(1_u64))

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -227,9 +227,9 @@ pub mod evm {
 
 pub mod democracy {
 	use crate::{currency::UNIT, time::MINUTES, Balance, BlockNumber};
-	pub const LAUNCH_PERIOD: BlockNumber = 10 * 24 * 60 * MINUTES; // 10 days
-	pub const VOTING_PERIOD: BlockNumber = 10 * 24 * 60 * MINUTES; // 10 days
-	pub const FASTTRACK_VOTING_PERIOD: BlockNumber = 3 * 24 * 60 * MINUTES; // 3 days
+	pub const LAUNCH_PERIOD: BlockNumber = 2 * 24 * 60 * MINUTES; // 2 days
+	pub const VOTING_PERIOD: BlockNumber = 7 * 24 * 60 * MINUTES; // 7 days
+	pub const FASTTRACK_VOTING_PERIOD: BlockNumber = 2 * 24 * 60 * MINUTES; // 2 days
 	pub const MINIMUM_DEPOSIT: Balance = 1000 * UNIT; // 1000 TNT
 	pub const ENACTMENT_PERIOD: BlockNumber = 3 * 24 * 60 * MINUTES; // 3 days
 	pub const COOLOFF_PERIOD: BlockNumber = 3 * 24 * 60 * MINUTES; // 3 days
@@ -239,12 +239,13 @@ pub mod democracy {
 pub mod elections {
 	use crate::{currency::UNIT, time::DAYS, Balance, BlockNumber};
 
-	pub const CANDIDACY_BOND: Balance = 10 * UNIT;
+	pub const CANDIDACY_BOND: Balance = 1_000 * UNIT;
 	pub const TERM_DURATION: BlockNumber = 7 * DAYS;
-	pub const DESIRED_MEMBERS: u32 = 13;
-	pub const DESIRED_RUNNERS_UP: u32 = 7;
-	pub const MAX_CANDIDATES: u32 = 10;
-	pub const MAX_VOTERS: u32 = 5;
+	pub const DESIRED_MEMBERS: u32 = 5;
+	pub const DESIRED_RUNNERS_UP: u32 = 3;
+	pub const MAX_CANDIDATES: u32 = 64;
+	pub const MAX_VOTERS: u32 = 512;
+	pub const MAX_VOTES_PER_VOTER: u32 = 32;
 	pub const ELECTIONS_PHRAGMEN_PALLET_ID: frame_support::traits::LockIdentifier = *b"phrelect";
 }
 
@@ -274,10 +275,10 @@ pub mod treasury {
 pub mod staking {
 	// Six sessions in an era (24 hours).
 	pub const SESSIONS_PER_ERA: sp_staking::SessionIndex = 6;
-	// 28 eras for unbonding (28 days).
-	pub const BONDING_DURATION: sp_staking::EraIndex = 28;
-	// 27 eras for slash defer duration (27 days).
-	pub const SLASH_DEFER_DURATION: sp_staking::EraIndex = 27;
+	// 14 eras for unbonding (14 days).
+	pub const BONDING_DURATION: sp_staking::EraIndex = 14;
+	// 27 eras for slash defer duration (10 days).
+	pub const SLASH_DEFER_DURATION: sp_staking::EraIndex = 10;
 	pub const MAX_NOMINATOR_REWARDED_PER_VALIDATOR: u32 = 256;
 	pub const OFFENDING_VALIDATOR_THRESHOLD: sp_arithmetic::Perbill =
 		sp_arithmetic::Perbill::from_percent(17);

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -264,7 +264,7 @@ impl pallet_timestamp::Config for Runtime {
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = EXISTENTIAL_DEPOSIT;
+	pub const ExistentialDeposit: u128 = EXISTENTIAL_DEPOSIT / 100_000_000;
 	pub const TransferFee: u128 = MILLIUNIT;
 	pub const CreationFee: u128 = MILLIUNIT;
 	pub const MaxLocks: u32 = 50;
@@ -392,10 +392,6 @@ impl pallet_grandpa::Config for Runtime {
 	type KeyOwnerProof = sp_core::Void;
 	type MaxNominators = MaxNominatorRewardedPerValidator;
 	type WeightInfo = ();
-}
-
-parameter_types! {
-	pub const UncleGenerations: u32 = 0;
 }
 
 impl pallet_authorship::Config for Runtime {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Removes light client from mainnet runtime until tested on testnet (and updated against Cancun upgrade or external partner)
- Updates values

### Findings
- [ ] Update `MockMPCHandler` or remove/block in runtime
- [ ] Update `MockJobToFeeHandler`, document decision, collaborate to implement if needed.
- [ ] Update `MockMisbehaviorHandler`, document decision or remove/block in runtime.
- [ ] Remove `Mock` as a prefix for naming things in mainnet runtime.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
