### PR TITLE
fix: Added `types` properties to `package.json` file

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -3,6 +3,8 @@
   "version": "0.5.4",
   "description": "Polkadot.js type definitions required for interacting with Webb's tangle network",
   "main": "./build/index.js",
+  "types": "./build/index.d.ts",
+  "typings": "./build/index.d.ts",
   "author": "Webb Developers <drew@webb.tools>",
   "license": "Apache-2.0",
   "type": "commonjs",


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Export the `types` properly on the `tangle-substrate-types`.

cc @1xstj, I may need your assistance in publishing the package to npm. Thank you!
