### PR TITLE
Make precompiles callable

### DIFF
--- a/node/src/chainspec/testnet.rs
+++ b/node/src/chainspec/testnet.rs
@@ -33,9 +33,9 @@ use tangle_crypto_primitives::crypto::AuthorityId as RoleKeyId;
 use tangle_primitives::types::BlockNumber;
 use tangle_testnet_runtime::{
 	AccountId, BabeConfig, Balance, BalancesConfig, ClaimsConfig, EVMChainIdConfig, EVMConfig,
-	ElectionsConfig, ImOnlineConfig, MaxVestingSchedules, Perbill, RuntimeGenesisConfig,
-	SessionConfig, Signature, StakerStatus, StakingConfig, SudoConfig, SystemConfig, UNIT,
-	WASM_BINARY,
+	ElectionsConfig, ImOnlineConfig, MaxVestingSchedules, Perbill, Precompiles,
+	RuntimeGenesisConfig, SessionConfig, Signature, StakerStatus, StakingConfig, SudoConfig,
+	SystemConfig, UNIT, WASM_BINARY,
 };
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
@@ -336,6 +336,13 @@ fn testnet_genesis(
 		}))
 		.collect();
 
+	// As precompiles are implemented inside the Runtime, they don't have a bytecode, and
+	// their account code is empty by default. However in Solidity calling a function of a
+	// contract often automatically adds a check that the contract bytecode is non-empty.
+	// For that reason a dummy code (0x60006000fd) can be inserted at the precompile address
+	// to pass that check.
+	let revert_bytecode = vec![0x60, 0x00, 0x60, 0x00, 0xFD];
+
 	RuntimeGenesisConfig {
 		system: SystemConfig { ..Default::default() },
 		sudo: SudoConfig { key: Some(root_key) },
@@ -398,6 +405,19 @@ fn testnet_genesis(
 				for (address, account) in genesis_evm_distribution {
 					map.insert(address, account);
 				}
+
+				Precompiles::used_addresses().for_each(|address| {
+					map.insert(
+						address,
+						fp_evm::GenesisAccount {
+							nonce: Default::default(),
+							balance: Default::default(),
+							storage: Default::default(),
+							code: revert_bytecode.clone(),
+						},
+					);
+				});
+
 				map
 			},
 			..Default::default()

--- a/precompiles/utils/src/precompile_set.rs
+++ b/precompiles/utils/src/precompile_set.rs
@@ -32,7 +32,6 @@ use fp_evm::{
 };
 use frame_support::pallet_prelude::Get;
 use impl_trait_for_tuples::impl_for_tuples;
-use pallet_evm::AddressMapping;
 use sp_core::{H160, H256};
 use sp_std::{
 	cell::RefCell, collections::btree_map::BTreeMap, marker::PhantomData, ops::RangeInclusive, vec,
@@ -1034,12 +1033,8 @@ impl<R: pallet_evm::Config, P: PrecompileSetFragment> PrecompileSetBuilder<R, P>
 	}
 
 	/// Return the list of addresses contained in this PrecompileSet.
-	pub fn used_addresses() -> impl Iterator<Item = R::AccountId> {
-		Self::new()
-			.inner
-			.used_addresses()
-			.into_iter()
-			.map(R::AddressMapping::into_account_id)
+	pub fn used_addresses() -> impl Iterator<Item = H160> {
+		Self::new().inner.used_addresses().into_iter()
 	}
 
 	pub fn summarize_checks(&self) -> Vec<PrecompileCheckSummary> {

--- a/runtime/testnet/src/frontier_evm.rs
+++ b/runtime/testnet/src/frontier_evm.rs
@@ -69,7 +69,7 @@ impl pallet_evm::Config for Runtime {
 	type AddressMapping = HashedAddressMapping<BlakeTwo256>;
 	type Currency = Balances;
 	type RuntimeEvent = RuntimeEvent;
-	type PrecompilesType = WebbPrecompiles<Self>;
+	type PrecompilesType = WebbPrecompiles<Runtime>;
 	type PrecompilesValue = PrecompilesValue;
 	type ChainId = EVMChainId;
 	type BlockGasLimit = BlockGasLimit;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -51,6 +51,7 @@ use pallet_transaction_payment::{
 use pallet_tx_pause::RuntimeCallNameOf;
 use parity_scale_codec::MaxEncodedLen;
 use parity_scale_codec::{Decode, Encode};
+use precompiles::WebbPrecompiles;
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
 use sp_api::impl_runtime_apis;
@@ -149,6 +150,9 @@ use tangle_primitives::{
 		TIP_REPORT_DEPOSIT_BASE, TREASURY_PALLET_ID,
 	},
 };
+
+// Precompiles
+pub type Precompiles = WebbPrecompiles<Runtime>;
 
 // Frontier
 use fp_rpc::TransactionStatus;

--- a/runtime/testnet/src/precompiles.rs
+++ b/runtime/testnet/src/precompiles.rs
@@ -29,7 +29,7 @@ use pallet_evm_precompile_vesting::VestingPrecompile;
 
 use precompile_utils::precompile_set::{
 	AcceptDelegateCall, AddressU64, CallableByContract, CallableByPrecompile, OnlyFrom,
-	PrecompileAt, PrecompileSetBuilder, SubcallWithMaxNesting,
+	PrecompileAt, PrecompileSetBuilder, PrecompilesInRangeInclusive, SubcallWithMaxNesting,
 };
 
 type EthereumPrecompilesChecks = (AcceptDelegateCall, CallableByContract, CallableByPrecompile);
@@ -122,4 +122,7 @@ pub type WebbPrecompilesAt<R> = (
 	>,
 );
 
-pub type WebbPrecompiles<R> = PrecompileSetBuilder<R, WebbPrecompilesAt<R>>;
+pub type WebbPrecompiles<R> = PrecompileSetBuilder<
+	R,
+	(PrecompilesInRangeInclusive<(AddressU64<1>, AddressU64<4095>), WebbPrecompilesAt<R>>,),
+>;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

As precompiles are implemented inside the Runtime, they don't have a bytecode, and their account code is empty by default. 
However in Solidity calling a function of a contract often automatically adds a check that the contract bytecode is non-empty.
For that reason a dummy code (0x60006000fd) can be inserted at the precompile address to pass that check.


**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
