### PR TITLE
Update ecdsa signature verification functions

### DIFF
--- a/pallets/dkg/src/functions.rs
+++ b/pallets/dkg/src/functions.rs
@@ -227,7 +227,7 @@ impl<T: Config> Pallet<T> {
 			Ok(())
 		};
 
-		let data = sp_io::hashing::keccak_256(&res.new_key).to_vec().try_into().unwrap_or_default();
+		let data = res.new_key.to_vec().try_into().unwrap_or_default();
 		let signature = res.signature.clone();
 		let verifying_key = res.key.clone();
 		let signature_scheme = res.signature_scheme.clone();

--- a/pallets/dkg/src/signatures_schemes/ecdsa.rs
+++ b/pallets/dkg/src/signatures_schemes/ecdsa.rs
@@ -68,8 +68,10 @@ pub fn verify_secp256k1_ecdsa_signature<T: Config>(
 	let signature = k256::ecdsa::Signature::from_slice(signature)
 		.map_err(|_| Error::<T>::InvalidSignatureDeserialization)?;
 
+	let message = keccak_256(msg);
+
 	ensure!(
-		verifying_key.verify_prehash(msg, &signature).map(|_| signature).is_ok(),
+		verifying_key.verify_prehash(&message, &signature).map(|_| signature).is_ok(),
 		Error::<T>::InvalidSignature
 	);
 	Ok(())
@@ -110,8 +112,10 @@ pub fn verify_secp256r1_ecdsa_signature<T: Config>(
 	let signature = p256::ecdsa::Signature::from_slice(signature)
 		.map_err(|_| Error::<T>::InvalidSignatureDeserialization)?;
 
+	let message = keccak_256(msg);
+
 	ensure!(
-		verifying_key.verify_prehash(msg, &signature).map(|_| signature).is_ok(),
+		verifying_key.verify_prehash(&message, &signature).map(|_| signature).is_ok(),
 		Error::<T>::InvalidSignature
 	);
 	Ok(())

--- a/pallets/dkg/src/tests.rs
+++ b/pallets/dkg/src/tests.rs
@@ -429,7 +429,6 @@ fn signature_verification_works_secp256k1_ecdsa() {
 		);
 
 		let signature = mock_signature_secp256k1_ecdsa(pub_key, pub_key);
-		let data_hash = keccak_256(&pub_key.to_raw_vec());
 		let job_to_verify = DKGTSSSignatureResult::<
 			MaxDataLen,
 			MaxKeyLen,
@@ -439,7 +438,7 @@ fn signature_verification_works_secp256k1_ecdsa() {
 			signature_scheme: DigitalSignatureScheme::EcdsaSecp256k1,
 			derivation_path: None,
 			signature: signature[..64].to_vec().try_into().unwrap(),
-			data: data_hash.to_vec().try_into().unwrap(),
+			data: pub_key.to_raw_vec().try_into().unwrap(),
 			verifying_key: pub_key.to_raw_vec().try_into().unwrap(),
 			chain_code: None,
 		};
@@ -504,7 +503,7 @@ fn signature_verification_works_secp256r1_ecdsa() {
 			signature_scheme: DigitalSignatureScheme::EcdsaSecp256r1,
 			derivation_path: None,
 			signature: signature.to_vec().try_into().unwrap(),
-			data: prehash.to_vec().try_into().unwrap(),
+			data: message.to_vec().try_into().unwrap(),
 			verifying_key: public_key
 				.to_encoded_point(true)
 				.to_bytes()

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1214,7 +1214,7 @@ parameter_types! {
 parameter_types! {
 	#[derive(Clone, RuntimeDebug, Eq, PartialEq, TypeInfo, Encode, Decode)]
 	#[derive(Serialize, Deserialize)]
-	pub const MaxSubmissionLen: u32 = 32;
+	pub const MaxSubmissionLen: u32 = 60_000_000;
 }
 
 parameter_types! {


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

Following are changes made to store result with original message on chain 

- Instead of passing hashed messaged to `verify_ecdsa_signature` methods now will be passing original message which will be later hashed inside the function.
- Update `MaxSubmissionLen` to 60_000_000

```rust

pub fn verify_secp256k1_ecdsa_signature<T: Config>(
	msg: &[u8],  // Original message bytes
	signature: &[u8],
	expected_key: &[u8],
	derivation_path: &Option<BoundedVec<u8, T::MaxAdditionalParamsLen>>,
	chain_code: Option<[u8; 32]>
) -> DispatchResult {

	...
	let signature = k256::ecdsa::Signature::from_slice(signature)
		.map_err(|_| Error::<T>::InvalidSignatureDeserialization)?;

	// Hash message here
	let message = keccak_256(msg);

	ensure!(
		verifying_key.verify_prehash(&message, &signature).map(|_| signature).is_ok(),
		Error::<T>::InvalidSignature
	);
}
```



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
