### PR TITLE
Precompiles to verify Schnorr and Bls381 Signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15646,6 +15646,7 @@ dependencies = [
  "pallet-evm-precompile-sha3fips",
  "pallet-evm-precompile-simple",
  "pallet-evm-precompile-staking",
+ "pallet-evm-precompile-verify-bls381-signature",
  "pallet-evm-precompile-verify-ecdsa-secp256k1-signature",
  "pallet-evm-precompile-verify-ecdsa-secp256r1-signature",
  "pallet-evm-precompile-verify-ecdsa-stark-signature",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8576,6 +8576,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-precompile-verify-schnorr-signatures"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "elliptic-curve",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "frost-core",
+ "frost-ed25519",
+ "frost-ed448",
+ "frost-p256",
+ "frost-p384",
+ "frost-ristretto255",
+ "frost-secp256k1",
+ "frost-taproot",
+ "hex-literal 0.4.1",
+ "log",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-timestamp",
+ "parity-scale-codec 3.6.12",
+ "precompile-utils",
+ "rand_core 0.6.4",
+ "scale-info",
+ "serde",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
+]
+
+[[package]]
 name = "pallet-evm-precompile-vesting"
 version = "0.1.0"
 dependencies = [
@@ -15592,6 +15625,7 @@ dependencies = [
  "pallet-evm-precompile-verify-ecdsa-secp256k1-signature",
  "pallet-evm-precompile-verify-ecdsa-secp256r1-signature",
  "pallet-evm-precompile-verify-ecdsa-stark-signature",
+ "pallet-evm-precompile-verify-schnorr-signatures",
  "pallet-evm-precompile-vesting",
  "pallet-grandpa",
  "pallet-hotfix-sufficients",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8499,6 +8499,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-evm-precompile-verify-bls381-signature"
+version = "0.1.0"
+dependencies = [
+ "derive_more",
+ "fp-evm",
+ "frame-support",
+ "frame-system",
+ "hex-literal 0.4.1",
+ "log",
+ "pallet-balances",
+ "pallet-evm",
+ "pallet-timestamp",
+ "parity-scale-codec 3.6.12",
+ "precompile-utils",
+ "scale-info",
+ "serde",
+ "snowbridge-milagro-bls",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?branch=release-polkadot-v1.7.0)",
+]
+
+[[package]]
 name = "pallet-evm-precompile-verify-ecdsa-secp256k1-signature"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
  "precompiles/verify-ecdsa-secp256k1-signature",
  "precompiles/verify-ecdsa-secp256r1-signature",
  "precompiles/verify-ecdsa-stark-signature",
+ "precompiles/verify-schnorr-signatures",
  "tangle-subxt",
  "examples/*",
  "evm-tracer"
@@ -321,6 +322,7 @@ pallet-evm-precompile-vesting = { path = "precompiles/vesting", default-features
 pallet-evm-precompile-verify-ecdsa-secp256k1-signature = { path = "precompiles/verify-ecdsa-secp256k1-signature", default-features = false }
 pallet-evm-precompile-verify-ecdsa-secp256r1-signature = { path = "precompiles/verify-ecdsa-secp256r1-signature", default-features = false }
 pallet-evm-precompile-verify-ecdsa-stark-signature = { path = "precompiles/verify-ecdsa-stark-signature", default-features = false }
+pallet-evm-precompile-verify-schnorr-signatures  = { path = "precompiles/verify-schnorr-signatures", default-features = false }
 
 # EVM & Ethereum
 # (wasm)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ members = [
  "precompiles/verify-ecdsa-secp256r1-signature",
  "precompiles/verify-ecdsa-stark-signature",
  "precompiles/verify-schnorr-signatures",
+ "precompiles/verify-bls381-signature",
  "tangle-subxt",
  "examples/*",
  "evm-tracer"
@@ -323,6 +324,7 @@ pallet-evm-precompile-verify-ecdsa-secp256k1-signature = { path = "precompiles/v
 pallet-evm-precompile-verify-ecdsa-secp256r1-signature = { path = "precompiles/verify-ecdsa-secp256r1-signature", default-features = false }
 pallet-evm-precompile-verify-ecdsa-stark-signature = { path = "precompiles/verify-ecdsa-stark-signature", default-features = false }
 pallet-evm-precompile-verify-schnorr-signatures  = { path = "precompiles/verify-schnorr-signatures", default-features = false }
+pallet-evm-precompile-verify-bls381-signature  = { path = "precompiles/verify-bls381-signature", default-features = false }
 
 # EVM & Ethereum
 # (wasm)

--- a/precompiles/verify-bls381-signature/Bls381.sol
+++ b/precompiles/verify-bls381-signature/Bls381.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.0;
+
+/**
+ * @title Bls-381 interface to verify isgnature.
+ */
+interface IBls381 {
+    /**
+     * @dev Verify signed message .
+     * @return A boolean confirming whether the public key is signer for the message. 
+     */
+    function verify(
+        bytes32 public_key,
+        bytes calldata signature,
+        bytes calldata message
+    ) external view returns (bool);
+}

--- a/precompiles/verify-bls381-signature/Cargo.toml
+++ b/precompiles/verify-bls381-signature/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "pallet-evm-precompile-verify-bls381-signature"
+version = "0.1.0"
+authors = { workspace = true }
+edition = "2021"
+description = "A Precompile to verify Bls381 signatures"
+
+[dependencies]
+log = { workspace = true }
+snowbridge-milagro-bls = { workspace = true, default-features = false }
+precompile-utils = { workspace = true }
+
+# Substrate
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
+
+
+
+# Frontier
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
+
+[dev-dependencies]
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
+
+precompile-utils = { workspace = true, features = ["std", "testing"] }
+
+# Substrate
+pallet-balances = { workspace = true, features = ["std"] }
+pallet-timestamp = { workspace = true, features = ["std"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+sp-io = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+  "fp-evm/std",
+  "pallet-evm/std",
+  "parity-scale-codec/std",
+  "sp-core/std",
+  "precompile-utils/std",
+  "sp-std/std",
+  "snowbridge-milagro-bls/std",
+
+]

--- a/precompiles/verify-bls381-signature/src/lib.rs
+++ b/precompiles/verify-bls381-signature/src/lib.rs
@@ -1,0 +1,80 @@
+// This file is part of Tangle.
+// Copyright (C) 2022-2024 Webb Technologies Inc.
+//
+// Tangle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Tangle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use fp_evm::PrecompileHandle;
+use precompile_utils::prelude::*;
+use sp_core::keccak_256;
+use sp_core::ConstU32;
+use sp_std::marker::PhantomData;
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+/// A precompile to verify Bls-381 signatures
+pub struct Bls381Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> Bls381Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<96>>,
+		signature_bytes: BoundedBytes<ConstU32<384>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		log::trace!(
+			target: "Bls-381-Precompile",
+			"Verify signature {:?} for public {:?} and message {:?}",
+			signature_bytes, public_bytes, message,
+		);
+
+		let public_key = if let Ok(p_key) =
+			snowbridge_milagro_bls::PublicKey::from_uncompressed_bytes(&public_bytes)
+		{
+			p_key
+		} else {
+			return Ok(false);
+		};
+
+		let signature =
+			if let Ok(sig) = snowbridge_milagro_bls::Signature::from_bytes(&signature_bytes) {
+				sig
+			} else {
+				return Ok(false);
+			};
+		let signed_data = keccak_256(&message);
+
+		let is_confirmed = signature.verify(&signed_data, &public_key);
+
+		log::trace!(
+			target: "Bls-381-Precompile",
+			"Verified signature {:?} is {:?}",
+			signature, is_confirmed,
+		);
+
+		Ok(is_confirmed)
+	}
+}

--- a/precompiles/verify-bls381-signature/src/mock.rs
+++ b/precompiles/verify-bls381-signature/src/mock.rs
@@ -1,0 +1,272 @@
+// This file is part of Tangle.
+// Copyright (C) 2022-2024 Webb Technologies Inc.
+//
+// Tangle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Tangle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Test utilities
+use super::*;
+use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
+use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use precompile_utils::{precompile_set::*, testing::MockAccount};
+use serde::{Deserialize, Serialize};
+use sp_core::{sr25519::Public as sr25519Public, H160, H256, U256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	AccountId32, BuildStorage, Perbill,
+};
+
+pub type AccountId = MockAccount;
+pub type Balance = u128;
+
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+const PRECOMPILE_ADDRESS_BYTES: [u8; 32] = [
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+];
+
+#[derive(
+	Eq,
+	PartialEq,
+	Ord,
+	PartialOrd,
+	Clone,
+	Encode,
+	Decode,
+	Debug,
+	MaxEncodedLen,
+	Serialize,
+	Deserialize,
+	derive_more::Display,
+	scale_info::TypeInfo,
+)]
+pub enum TestAccount {
+	Empty,
+	Alex,
+	Bobo,
+	Dave,
+	Charlie,
+	Eve,
+	PrecompileAddress,
+}
+
+impl Default for TestAccount {
+	fn default() -> Self {
+		Self::Empty
+	}
+}
+
+// needed for associated type in pallet_evm
+impl AddressMapping<AccountId32> for TestAccount {
+	fn into_account_id(h160_account: H160) -> AccountId32 {
+		match h160_account {
+			a if a == H160::repeat_byte(0x01) => TestAccount::Alex.into(),
+			a if a == H160::repeat_byte(0x02) => TestAccount::Bobo.into(),
+			a if a == H160::repeat_byte(0x03) => TestAccount::Charlie.into(),
+			a if a == H160::repeat_byte(0x04) => TestAccount::Dave.into(),
+			a if a == H160::repeat_byte(0x05) => TestAccount::Eve.into(),
+			a if a == H160::from_low_u64_be(6) => TestAccount::PrecompileAddress.into(),
+			_ => TestAccount::Empty.into(),
+		}
+	}
+}
+
+impl AddressMapping<sp_core::sr25519::Public> for TestAccount {
+	fn into_account_id(h160_account: H160) -> sp_core::sr25519::Public {
+		match h160_account {
+			a if a == H160::repeat_byte(0x01) => sr25519Public::from_raw([1u8; 32]),
+			a if a == H160::repeat_byte(0x02) => sr25519Public::from_raw([2u8; 32]),
+			a if a == H160::repeat_byte(0x03) => sr25519Public::from_raw([3u8; 32]),
+			a if a == H160::repeat_byte(0x04) => sr25519Public::from_raw([4u8; 32]),
+			a if a == H160::repeat_byte(0x05) => sr25519Public::from_raw([5u8; 32]),
+			a if a == H160::from_low_u64_be(6) => sr25519Public::from_raw(PRECOMPILE_ADDRESS_BYTES),
+			_ => sr25519Public::from_raw([0u8; 32]),
+		}
+	}
+}
+
+impl From<TestAccount> for H160 {
+	fn from(x: TestAccount) -> H160 {
+		match x {
+			TestAccount::Alex => H160::repeat_byte(0x01),
+			TestAccount::Bobo => H160::repeat_byte(0x02),
+			TestAccount::Charlie => H160::repeat_byte(0x03),
+			TestAccount::Dave => H160::repeat_byte(0x04),
+			TestAccount::Eve => H160::repeat_byte(0x05),
+			TestAccount::PrecompileAddress => H160::from_low_u64_be(6),
+			_ => Default::default(),
+		}
+	}
+}
+
+impl From<TestAccount> for AccountId32 {
+	fn from(x: TestAccount) -> Self {
+		match x {
+			TestAccount::Alex => AccountId32::from([1u8; 32]),
+			TestAccount::Bobo => AccountId32::from([2u8; 32]),
+			TestAccount::Charlie => AccountId32::from([3u8; 32]),
+			TestAccount::Dave => AccountId32::from([4u8; 32]),
+			TestAccount::Eve => AccountId32::from([5u8; 32]),
+			TestAccount::PrecompileAddress => AccountId32::from(PRECOMPILE_ADDRESS_BYTES),
+			_ => AccountId32::from([0u8; 32]),
+		}
+	}
+}
+
+impl From<TestAccount> for sp_core::sr25519::Public {
+	fn from(x: TestAccount) -> Self {
+		match x {
+			TestAccount::Alex => sr25519Public::from_raw([1u8; 32]),
+			TestAccount::Bobo => sr25519Public::from_raw([2u8; 32]),
+			TestAccount::Charlie => sr25519Public::from_raw([3u8; 32]),
+			TestAccount::Dave => sr25519Public::from_raw([4u8; 32]),
+			TestAccount::Eve => sr25519Public::from_raw([5u8; 32]),
+			TestAccount::PrecompileAddress => sr25519Public::from_raw(PRECOMPILE_ADDRESS_BYTES),
+			_ => sr25519Public::from_raw([0u8; 32]),
+		}
+	}
+}
+
+construct_runtime!(
+	pub enum Runtime
+	{
+		System: frame_system,
+		Balances: pallet_balances,
+		Evm: pallet_evm,
+		Timestamp: pallet_timestamp,
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u32 = 250;
+	pub const MaximumBlockWeight: Weight = Weight::from_parts(1024, 1);
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = Everything;
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type Block = Block;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type RuntimeTask = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 1;
+}
+impl pallet_balances::Config for Runtime {
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 4];
+	type MaxLocks = ();
+	type Balance = Balance;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+}
+
+const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+
+parameter_types! {
+	pub BlockGasLimit: U256 = U256::from(u64::MAX);
+	pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
+	pub const WeightPerGas: Weight = Weight::from_parts(1, 0);
+	pub GasLimitPovSizeRatio: u64 = {
+		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
+		block_gas_limit.saturating_div(MAX_POV_SIZE)
+	};
+}
+
+pub type Precompiles<R> =
+	PrecompileSetBuilder<R, (PrecompileAt<AddressU64<1>, Bls381Precompile<R>>,)>;
+
+pub type PCall = Bls381PrecompileCall<Runtime>;
+
+parameter_types! {
+	pub SuicideQuickClearLimit: u32 = 0;
+}
+
+impl pallet_evm::Config for Runtime {
+	type FeeCalculator = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = AccountId;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = Precompiles<Runtime>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ();
+	type OnChargeTransaction = ();
+	type BlockGasLimit = BlockGasLimit;
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = ();
+	type OnCreate = ();
+	type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type Timestamp = Timestamp;
+	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 5;
+}
+impl pallet_timestamp::Config for Runtime {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+#[derive(Default)]
+pub(crate) struct ExtBuilder;
+
+impl ExtBuilder {
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let t = frame_system::GenesisConfig::<Runtime>::default()
+			.build_storage()
+			.expect("Frame system builds valid default genesis config");
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}

--- a/precompiles/verify-bls381-signature/src/tests.rs
+++ b/precompiles/verify-bls381-signature/src/tests.rs
@@ -1,0 +1,114 @@
+// This file is part of Tangle.
+// Copyright (C) 2022-2024 Webb Technologies Inc.
+//
+// Tangle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Tangle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::mock::*;
+use hex_literal::hex;
+use precompile_utils::testing::*;
+use snowbridge_milagro_bls::{PublicKey, SecretKey, Signature};
+use sp_core::{keccak_256, H160};
+
+fn precompiles() -> Precompiles<Runtime> {
+	PrecompilesValue::get()
+}
+
+#[test]
+fn wrong_signature_length_returns_false() {
+	ExtBuilder::default().build().execute_with(|| {
+		const BLS_SECRET_KEY: [u8; 32] = [
+			78, 252, 122, 126, 32, 0, 75, 89, 252, 31, 42, 130, 254, 88, 6, 90, 138, 202, 135, 194,
+			233, 117, 181, 75, 96, 238, 79, 100, 237, 59, 140, 111,
+		];
+		let secret_key = SecretKey::from_bytes(&BLS_SECRET_KEY).unwrap();
+		let pub_key = PublicKey::from_secret_key(&secret_key);
+		let signature = hex!["0042"];
+		let message = hex!["00"];
+
+		precompiles()
+			.prepare_test(
+				TestAccount::Alex,
+				H160::from_low_u64_be(1),
+				PCall::verify {
+					public_bytes: pub_key.as_uncompressed_bytes().into(),
+					signature_bytes: signature.into(),
+					message: message.into(),
+				},
+			)
+			.expect_no_logs()
+			.execute_returns(false);
+	});
+}
+
+#[test]
+fn bad_signature_returns_false() {
+	ExtBuilder::default().build().execute_with(|| {
+		const BLS_SECRET_KEY: [u8; 32] = [
+			78, 252, 122, 126, 32, 0, 75, 89, 252, 31, 42, 130, 254, 88, 6, 90, 138, 202, 135, 194,
+			233, 117, 181, 75, 96, 238, 79, 100, 237, 59, 140, 111,
+		];
+
+		const BLS_DATA_TO_SIGN: &[u8; 13] = b"Hello, world!";
+
+		let secret_key = SecretKey::from_bytes(&BLS_SECRET_KEY).unwrap();
+		let pub_key = PublicKey::from_secret_key(&secret_key);
+		let msg_hash = keccak_256(BLS_DATA_TO_SIGN);
+		let signature = Signature::new(&msg_hash, &secret_key);
+
+		let bad_message = hex!["00"];
+
+		precompiles()
+			.prepare_test(
+				TestAccount::Alex,
+				H160::from_low_u64_be(1),
+				PCall::verify {
+					public_bytes: pub_key.as_uncompressed_bytes().into(),
+					signature_bytes: signature.as_bytes()[..10].to_vec().into(),
+					message: bad_message.into(),
+				},
+			)
+			.expect_no_logs()
+			.execute_returns(false);
+	});
+}
+
+#[test]
+fn signature_verification_works_with_bls318() {
+	ExtBuilder::default().build().execute_with(|| {
+		const BLS_SECRET_KEY: [u8; 32] = [
+			78, 252, 122, 126, 32, 0, 75, 89, 252, 31, 42, 130, 254, 88, 6, 90, 138, 202, 135, 194,
+			233, 117, 181, 75, 96, 238, 79, 100, 237, 59, 140, 111,
+		];
+
+		const BLS_DATA_TO_SIGN: &[u8; 13] = b"Hello, world!";
+
+		let secret_key = SecretKey::from_bytes(&BLS_SECRET_KEY).unwrap();
+		let pub_key = PublicKey::from_secret_key(&secret_key);
+		let msg_hash = keccak_256(BLS_DATA_TO_SIGN);
+		let signature = Signature::new(&msg_hash, &secret_key);
+
+		precompiles()
+			.prepare_test(
+				TestAccount::Alex,
+				H160::from_low_u64_be(1),
+				PCall::verify {
+					public_bytes: pub_key.as_uncompressed_bytes().into(),
+					signature_bytes: signature.as_bytes().to_vec().into(),
+					message: BLS_DATA_TO_SIGN.to_vec().into(),
+				},
+			)
+			.expect_no_logs()
+			.execute_returns(true);
+	});
+}

--- a/precompiles/verify-schnorr-signatures/Cargo.toml
+++ b/precompiles/verify-schnorr-signatures/Cargo.toml
@@ -1,0 +1,70 @@
+[package]
+name = "pallet-evm-precompile-verify-schnorr-signatures"
+version = "0.1.0"
+authors = { workspace = true }
+edition = "2021"
+description = "A Precompile to verify schnorr signatures"
+
+[dependencies]
+log = { workspace = true }
+precompile-utils = { workspace = true }
+
+frost-core = { workspace = true, default-features = false }
+frost-ed25519 = { workspace = true, default-features = false }
+elliptic-curve = { version = "0.13", features = ["hash2curve"], default-features = false }
+frost-ed448 = { workspace = true, default-features = false }
+frost-ristretto255 = { workspace = true, default-features = false }
+frost-secp256k1 = { workspace = true, default-features = false }
+frost-taproot = { workspace = true, default-features = false }
+frost-p256 = { workspace = true, default-features = false }
+frost-p384 = { workspace = true, default-features = false }
+
+# Substrate
+sp-core = { workspace = true }
+sp-std = { workspace = true }
+sp-io = { workspace = true }
+parity-scale-codec = { workspace = true, features = ["max-encoded-len"] }
+
+
+
+# Frontier
+fp-evm = { workspace = true }
+pallet-evm = { workspace = true }
+
+[dev-dependencies]
+derive_more = { workspace = true }
+hex-literal = { workspace = true }
+scale-info = { workspace = true }
+serde = { workspace = true }
+rand_core = { workspace = true }
+
+precompile-utils = { workspace = true, features = ["std", "testing"] }
+
+# Substrate
+pallet-balances = { workspace = true, features = ["std"] }
+pallet-timestamp = { workspace = true, features = ["std"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+sp-runtime = { workspace = true }
+
+
+[features]
+default = ["std"]
+std = [
+  "fp-evm/std",
+  "pallet-evm/std",
+  "parity-scale-codec/std",
+  "sp-core/std",
+  "precompile-utils/std",
+  "sp-std/std",
+  "sp-io/std",
+  "frost-core/std",
+  "frost-ed25519/std",
+  "elliptic-curve/std",
+  "frost-ed448/std",
+  "frost-ristretto255/std",
+  "frost-secp256k1/std",
+  "frost-taproot/std",
+  "frost-p256/std",
+  "frost-p384/std",
+]

--- a/precompiles/verify-schnorr-signatures/SchnorrSignatureVerifier.sol
+++ b/precompiles/verify-schnorr-signatures/SchnorrSignatureVerifier.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.8.0;
+
+/**
+ * @title ISchnorrSignatureVerifier interface to verify schnorr isgnature.
+ */
+interface ISchnorrSignatureVerifier {
+    /**
+     * @dev Verify signed message .
+     * @return A boolean confirming whether the public key is signer for the message. 
+     */
+    function verify(
+        bytes32 public_key,
+        bytes calldata signature,
+        bytes calldata message
+    ) external view returns (bool);
+}

--- a/precompiles/verify-schnorr-signatures/src/lib.rs
+++ b/precompiles/verify-schnorr-signatures/src/lib.rs
@@ -18,10 +18,10 @@
 
 use fp_evm::PrecompileHandle;
 use precompile_utils::prelude::*;
-use sp_core::ConstU32;
-use sp_std::marker::PhantomData;
 use sp_core::sr25519;
+use sp_core::ConstU32;
 use sp_io::{crypto::sr25519_verify, hashing::keccak_256};
+use sp_std::marker::PhantomData;
 
 use frost_core::{signature::Signature, verifying_key::VerifyingKey};
 use frost_ed25519::Ed25519Sha512;
@@ -31,7 +31,6 @@ use frost_p384::P384Sha384;
 use frost_ristretto255::Ristretto255Sha512;
 use frost_secp256k1::Secp256K1Sha256;
 use frost_taproot::Secp256K1Taproot;
-
 
 #[cfg(test)]
 mod mock;
@@ -62,8 +61,6 @@ pub fn to_slice_32(val: &[u8]) -> Option<[u8; 32]> {
 	None
 }
 
-
-
 /// A precompile to verify SchnorrSr25519 signature
 pub struct SchnorrSr25519Precompile<Runtime>(PhantomData<Runtime>);
 
@@ -83,20 +80,21 @@ impl<Runtime: pallet_evm::Config> SchnorrSr25519Precompile<Runtime> {
 		let message: Vec<u8> = message.into();
 
 		// Convert the signature from bytes to sr25519::Signature
-		let signature: sr25519::Signature = signature_bytes.as_slice().try_into().map_err(|_| revert("Invalid Signature"))?;
+		let signature: sr25519::Signature =
+			signature_bytes.as_slice().try_into().map_err(|_| revert("Invalid Signature"))?;
 
 		// Convert public key from bytes to sr25519::Public
-		let public_key: sr25519::Public = sr25519::Public(public_bytes.try_into().map_err(|_| revert("Invalid Publci Key"))?);
+		let public_key: sr25519::Public =
+			sr25519::Public(public_bytes.try_into().map_err(|_| revert("Invalid Publci Key"))?);
 
 		// Compute its keccak256 hash
 		let hash = keccak_256(&message);
 
 		// Verify the Schnorr signature using sr25519_verify
-		let is_confirmed = sr25519_verify(&signature,&hash,&public_key);
+		let is_confirmed = sr25519_verify(&signature, &hash, &public_key);
 		Ok(is_confirmed)
 	}
 }
-
 
 /// A precompile to verify SchnorrSecp256k1 signature
 pub struct SchnorrSecp256k1Precompile<Runtime>(PhantomData<Runtime>);
@@ -162,7 +160,6 @@ impl<Runtime: pallet_evm::Config> SchnorrEd25519Precompile<Runtime> {
 
 /// A precompile to verify SchnorrEd448 signature
 pub struct SchnorrEd448Precompile<Runtime>(PhantomData<Runtime>);
-
 
 #[precompile_utils::precompile]
 impl<Runtime: pallet_evm::Config> SchnorrEd448Precompile<Runtime> {

--- a/precompiles/verify-schnorr-signatures/src/lib.rs
+++ b/precompiles/verify-schnorr-signatures/src/lib.rs
@@ -1,0 +1,317 @@
+// This file is part of Tangle.
+// Copyright (C) 2022-2024 Webb Technologies Inc.
+//
+// Tangle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Tangle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use fp_evm::PrecompileHandle;
+use precompile_utils::prelude::*;
+use sp_core::ConstU32;
+use sp_std::marker::PhantomData;
+use sp_core::sr25519;
+use sp_io::{crypto::sr25519_verify, hashing::keccak_256};
+
+use frost_core::{signature::Signature, verifying_key::VerifyingKey};
+use frost_ed25519::Ed25519Sha512;
+use frost_ed448::Ed448Shake256;
+use frost_p256::P256Sha256;
+use frost_p384::P384Sha384;
+use frost_ristretto255::Ristretto255Sha512;
+use frost_secp256k1::Secp256K1Sha256;
+use frost_taproot::Secp256K1Taproot;
+
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+
+/// Macro to verify a Schnorr signature using the specified signature scheme.
+macro_rules! verify_signature {
+	($impl_type:ty, $key:expr, $signature:expr, $msg:expr, $key_default:expr, $sig_default:expr) => {{
+		let verifying_key: VerifyingKey<$impl_type> =
+			VerifyingKey::deserialize($key.try_into().unwrap_or($key_default))
+				.map_err(|_| revert("InvalidVerifyingKeyDeserialization"))?;
+		let sig: Signature<$impl_type> =
+			Signature::deserialize($signature.try_into().unwrap_or($sig_default))
+				.map_err(|_| revert("InvalidSignatureDeserialization"))?;
+		verifying_key.verify($msg, &sig).map_err(|_| revert("InvalidSignature"))?
+	}};
+}
+
+/// Utility function to create slice of fixed size
+pub fn to_slice_32(val: &[u8]) -> Option<[u8; 32]> {
+	if val.len() == 32 {
+		let mut key = [0u8; 32];
+		key[..32].copy_from_slice(val);
+
+		return Some(key);
+	}
+	None
+}
+
+
+
+/// A precompile to verify SchnorrSr25519 signature
+pub struct SchnorrSr25519Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrSr25519Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<32>>,
+		signature_bytes: BoundedBytes<ConstU32<65>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		// Convert the signature from bytes to sr25519::Signature
+		let signature: sr25519::Signature = signature_bytes.as_slice().try_into().map_err(|_| revert("Invalid Signature"))?;
+
+		// Convert public key from bytes to sr25519::Public
+		let public_key: sr25519::Public = sr25519::Public(public_bytes.try_into().map_err(|_| revert("Invalid Publci Key"))?);
+
+		// Compute its keccak256 hash
+		let hash = keccak_256(&message);
+
+		// Verify the Schnorr signature using sr25519_verify
+		let is_confirmed = sr25519_verify(&signature,&hash,&public_key);
+		Ok(is_confirmed)
+	}
+}
+
+
+/// A precompile to verify SchnorrSecp256k1 signature
+pub struct SchnorrSecp256k1Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrSecp256k1Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<33>>,
+		signature_bytes: BoundedBytes<ConstU32<65>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			Secp256K1Sha256,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 33],
+			[0u8; 65]
+		);
+
+		Ok(false)
+	}
+}
+
+/// A precompile to verify SchnorrEd25519 signature
+pub struct SchnorrEd25519Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrEd25519Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<32>>,
+		signature_bytes: BoundedBytes<ConstU32<64>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			Ed25519Sha512,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 32],
+			[0u8; 64]
+		);
+
+		Ok(false)
+	}
+}
+
+/// A precompile to verify SchnorrEd448 signature
+pub struct SchnorrEd448Precompile<Runtime>(PhantomData<Runtime>);
+
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrEd448Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<57>>,
+		signature_bytes: BoundedBytes<ConstU32<114>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			Ed448Shake256,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 57],
+			[0u8; 114]
+		);
+
+		Ok(false)
+	}
+}
+
+/// A precompile to verify SchnorrP256 signature
+pub struct SchnorrP256Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrP256Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<33>>,
+		signature_bytes: BoundedBytes<ConstU32<65>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			P256Sha256,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 33],
+			[0u8; 65]
+		);
+
+		Ok(false)
+	}
+}
+
+/// A precompile to verify SchnorrP384 signature
+pub struct SchnorrP384Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrP384Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<49>>,
+		signature_bytes: BoundedBytes<ConstU32<97>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			P384Sha384,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 49],
+			[0u8; 97]
+		);
+
+		Ok(false)
+	}
+}
+
+/// A precompile to verify SchnorrRistretto255 signature
+pub struct SchnorrRistretto255Precompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrRistretto255Precompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<32>>,
+		signature_bytes: BoundedBytes<ConstU32<64>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			Ristretto255Sha512,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 32],
+			[0u8; 64]
+		);
+
+		Ok(false)
+	}
+}
+
+/// A precompile to verify SchnorrTaproot signature
+pub struct SchnorrTaprootPrecompile<Runtime>(PhantomData<Runtime>);
+
+#[precompile_utils::precompile]
+impl<Runtime: pallet_evm::Config> SchnorrTaprootPrecompile<Runtime> {
+	#[precompile::public("verify(bytes,bytes,bytes)")]
+	#[precompile::view]
+	fn verify(
+		_handle: &mut impl PrecompileHandle,
+		public_bytes: BoundedBytes<ConstU32<33>>,
+		signature_bytes: BoundedBytes<ConstU32<65>>,
+		message: UnboundedBytes,
+	) -> EvmResult<bool> {
+		// Parse arguments
+		let public_bytes: Vec<u8> = public_bytes.into();
+		let signature_bytes: Vec<u8> = signature_bytes.into();
+		let message: Vec<u8> = message.into();
+
+		verify_signature!(
+			Secp256K1Taproot,
+			public_bytes.as_slice(),
+			signature_bytes.as_slice(),
+			&message,
+			[0u8; 33],
+			[0u8; 65]
+		);
+
+		Ok(false)
+	}
+}

--- a/precompiles/verify-schnorr-signatures/src/mock.rs
+++ b/precompiles/verify-schnorr-signatures/src/mock.rs
@@ -1,0 +1,282 @@
+// This file is part of Tangle.
+// Copyright (C) 2022-2024 Webb Technologies Inc.
+//
+// Tangle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Tangle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Test utilities
+use super::*;
+use frame_support::{construct_runtime, parameter_types, traits::Everything, weights::Weight};
+use pallet_evm::{AddressMapping, EnsureAddressNever, EnsureAddressRoot};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use precompile_utils::{precompile_set::*, testing::MockAccount};
+use serde::{Deserialize, Serialize};
+use sp_core::{sr25519::Public as sr25519Public, H160, H256, U256};
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	AccountId32, BuildStorage, Perbill,
+};
+
+pub type AccountId = MockAccount;
+pub type Balance = u128;
+
+type Block = frame_system::mocking::MockBlock<Runtime>;
+
+const PRECOMPILE_ADDRESS_BYTES: [u8; 32] = [
+	0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1,
+];
+
+#[derive(
+	Eq,
+	PartialEq,
+	Ord,
+	PartialOrd,
+	Clone,
+	Encode,
+	Decode,
+	Debug,
+	MaxEncodedLen,
+	Serialize,
+	Deserialize,
+	derive_more::Display,
+	scale_info::TypeInfo,
+)]
+pub enum TestAccount {
+	Empty,
+	Alex,
+	Bobo,
+	Dave,
+	Charlie,
+	Eve,
+	PrecompileAddress,
+}
+
+impl Default for TestAccount {
+	fn default() -> Self {
+		Self::Empty
+	}
+}
+
+// needed for associated type in pallet_evm
+impl AddressMapping<AccountId32> for TestAccount {
+	fn into_account_id(h160_account: H160) -> AccountId32 {
+		match h160_account {
+			a if a == H160::repeat_byte(0x01) => TestAccount::Alex.into(),
+			a if a == H160::repeat_byte(0x02) => TestAccount::Bobo.into(),
+			a if a == H160::repeat_byte(0x03) => TestAccount::Charlie.into(),
+			a if a == H160::repeat_byte(0x04) => TestAccount::Dave.into(),
+			a if a == H160::repeat_byte(0x05) => TestAccount::Eve.into(),
+			a if a == H160::from_low_u64_be(6) => TestAccount::PrecompileAddress.into(),
+			_ => TestAccount::Empty.into(),
+		}
+	}
+}
+
+impl AddressMapping<sp_core::sr25519::Public> for TestAccount {
+	fn into_account_id(h160_account: H160) -> sp_core::sr25519::Public {
+		match h160_account {
+			a if a == H160::repeat_byte(0x01) => sr25519Public::from_raw([1u8; 32]),
+			a if a == H160::repeat_byte(0x02) => sr25519Public::from_raw([2u8; 32]),
+			a if a == H160::repeat_byte(0x03) => sr25519Public::from_raw([3u8; 32]),
+			a if a == H160::repeat_byte(0x04) => sr25519Public::from_raw([4u8; 32]),
+			a if a == H160::repeat_byte(0x05) => sr25519Public::from_raw([5u8; 32]),
+			a if a == H160::from_low_u64_be(6) => sr25519Public::from_raw(PRECOMPILE_ADDRESS_BYTES),
+			_ => sr25519Public::from_raw([0u8; 32]),
+		}
+	}
+}
+
+impl From<TestAccount> for H160 {
+	fn from(x: TestAccount) -> H160 {
+		match x {
+			TestAccount::Alex => H160::repeat_byte(0x01),
+			TestAccount::Bobo => H160::repeat_byte(0x02),
+			TestAccount::Charlie => H160::repeat_byte(0x03),
+			TestAccount::Dave => H160::repeat_byte(0x04),
+			TestAccount::Eve => H160::repeat_byte(0x05),
+			TestAccount::PrecompileAddress => H160::from_low_u64_be(6),
+			_ => Default::default(),
+		}
+	}
+}
+
+impl From<TestAccount> for AccountId32 {
+	fn from(x: TestAccount) -> Self {
+		match x {
+			TestAccount::Alex => AccountId32::from([1u8; 32]),
+			TestAccount::Bobo => AccountId32::from([2u8; 32]),
+			TestAccount::Charlie => AccountId32::from([3u8; 32]),
+			TestAccount::Dave => AccountId32::from([4u8; 32]),
+			TestAccount::Eve => AccountId32::from([5u8; 32]),
+			TestAccount::PrecompileAddress => AccountId32::from(PRECOMPILE_ADDRESS_BYTES),
+			_ => AccountId32::from([0u8; 32]),
+		}
+	}
+}
+
+impl From<TestAccount> for sp_core::sr25519::Public {
+	fn from(x: TestAccount) -> Self {
+		match x {
+			TestAccount::Alex => sr25519Public::from_raw([1u8; 32]),
+			TestAccount::Bobo => sr25519Public::from_raw([2u8; 32]),
+			TestAccount::Charlie => sr25519Public::from_raw([3u8; 32]),
+			TestAccount::Dave => sr25519Public::from_raw([4u8; 32]),
+			TestAccount::Eve => sr25519Public::from_raw([5u8; 32]),
+			TestAccount::PrecompileAddress => sr25519Public::from_raw(PRECOMPILE_ADDRESS_BYTES),
+			_ => sr25519Public::from_raw([0u8; 32]),
+		}
+	}
+}
+
+construct_runtime!(
+	pub enum Runtime
+	{
+		System: frame_system,
+		Balances: pallet_balances,
+		Evm: pallet_evm,
+		Timestamp: pallet_timestamp,
+	}
+);
+
+parameter_types! {
+	pub const BlockHashCount: u32 = 250;
+	pub const MaximumBlockWeight: Weight = Weight::from_parts(1024, 1);
+	pub const MaximumBlockLength: u32 = 2 * 1024;
+	pub const AvailableBlockRatio: Perbill = Perbill::one();
+	pub const SS58Prefix: u8 = 42;
+}
+
+impl frame_system::Config for Runtime {
+	type BaseCallFilter = Everything;
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type Nonce = u64;
+	type Block = Block;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = BlockHashCount;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = pallet_balances::AccountData<Balance>;
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type BlockWeights = ();
+	type BlockLength = ();
+	type SS58Prefix = SS58Prefix;
+	type OnSetCode = ();
+	type RuntimeTask = ();
+	type MaxConsumers = frame_support::traits::ConstU32<16>;
+}
+parameter_types! {
+	pub const ExistentialDeposit: u128 = 1;
+}
+impl pallet_balances::Config for Runtime {
+	type MaxReserves = ();
+	type ReserveIdentifier = [u8; 4];
+	type MaxLocks = ();
+	type Balance = Balance;
+	type RuntimeEvent = RuntimeEvent;
+	type DustRemoval = ();
+	type ExistentialDeposit = ExistentialDeposit;
+	type AccountStore = System;
+	type WeightInfo = ();
+	type RuntimeHoldReason = RuntimeHoldReason;
+	type RuntimeFreezeReason = ();
+	type FreezeIdentifier = ();
+	type MaxFreezes = ();
+}
+
+const MAX_POV_SIZE: u64 = 5 * 1024 * 1024;
+
+parameter_types! {
+	pub BlockGasLimit: U256 = U256::from(u64::MAX);
+	pub PrecompilesValue: Precompiles<Runtime> = Precompiles::new();
+	pub const WeightPerGas: Weight = Weight::from_parts(1, 0);
+	pub GasLimitPovSizeRatio: u64 = {
+		let block_gas_limit = BlockGasLimit::get().min(u64::MAX.into()).low_u64();
+		block_gas_limit.saturating_div(MAX_POV_SIZE)
+	};
+}
+
+pub type Precompiles<R> =
+	PrecompileSetBuilder<R, (
+		PrecompileAt<AddressU64<1>, SchnorrSr25519Precompile<R>>,
+		PrecompileAt<AddressU64<2>, SchnorrSecp256k1Precompile<R>>,
+		PrecompileAt<AddressU64<3>, SchnorrEd25519Precompile<R>>,
+		PrecompileAt<AddressU64<4>, SchnorrEd448Precompile<R>>,
+		PrecompileAt<AddressU64<5>, SchnorrP256Precompile<R>>,
+		PrecompileAt<AddressU64<6>, SchnorrP384Precompile<R>>,
+		PrecompileAt<AddressU64<7>, SchnorrRistretto255Precompile<R>>,
+		PrecompileAt<AddressU64<8>, SchnorrTaprootPrecompile<R>>,
+
+	)>;
+
+pub type PcallSchnorrSr25519 = SchnorrSr25519PrecompileCall<Runtime>;
+
+parameter_types! {
+	pub SuicideQuickClearLimit: u32 = 0;
+}
+
+impl pallet_evm::Config for Runtime {
+	type FeeCalculator = ();
+	type GasWeightMapping = pallet_evm::FixedGasWeightMapping<Self>;
+	type WeightPerGas = WeightPerGas;
+	type CallOrigin = EnsureAddressRoot<AccountId>;
+	type WithdrawOrigin = EnsureAddressNever<AccountId>;
+	type AddressMapping = AccountId;
+	type Currency = Balances;
+	type RuntimeEvent = RuntimeEvent;
+	type Runner = pallet_evm::runner::stack::Runner<Self>;
+	type PrecompilesType = Precompiles<Runtime>;
+	type PrecompilesValue = PrecompilesValue;
+	type ChainId = ();
+	type OnChargeTransaction = ();
+	type BlockGasLimit = BlockGasLimit;
+	type BlockHashMapping = pallet_evm::SubstrateBlockHashMapping<Self>;
+	type FindAuthor = ();
+	type OnCreate = ();
+	type SuicideQuickClearLimit = SuicideQuickClearLimit;
+	type GasLimitPovSizeRatio = GasLimitPovSizeRatio;
+	type Timestamp = Timestamp;
+	type WeightInfo = pallet_evm::weights::SubstrateWeight<Runtime>;
+}
+
+parameter_types! {
+	pub const MinimumPeriod: u64 = 5;
+}
+impl pallet_timestamp::Config for Runtime {
+	type Moment = u64;
+	type OnTimestampSet = ();
+	type MinimumPeriod = MinimumPeriod;
+	type WeightInfo = ();
+}
+
+#[derive(Default)]
+pub(crate) struct ExtBuilder;
+
+impl ExtBuilder {
+	pub(crate) fn build(self) -> sp_io::TestExternalities {
+		let t = frame_system::GenesisConfig::<Runtime>::default()
+			.build_storage()
+			.expect("Frame system builds valid default genesis config");
+
+		let mut ext = sp_io::TestExternalities::new(t);
+		ext.execute_with(|| System::set_block_number(1));
+		ext
+	}
+}

--- a/precompiles/verify-schnorr-signatures/src/mock.rs
+++ b/precompiles/verify-schnorr-signatures/src/mock.rs
@@ -213,8 +213,9 @@ parameter_types! {
 	};
 }
 
-pub type Precompiles<R> =
-	PrecompileSetBuilder<R, (
+pub type Precompiles<R> = PrecompileSetBuilder<
+	R,
+	(
 		PrecompileAt<AddressU64<1>, SchnorrSr25519Precompile<R>>,
 		PrecompileAt<AddressU64<2>, SchnorrSecp256k1Precompile<R>>,
 		PrecompileAt<AddressU64<3>, SchnorrEd25519Precompile<R>>,
@@ -223,8 +224,8 @@ pub type Precompiles<R> =
 		PrecompileAt<AddressU64<6>, SchnorrP384Precompile<R>>,
 		PrecompileAt<AddressU64<7>, SchnorrRistretto255Precompile<R>>,
 		PrecompileAt<AddressU64<8>, SchnorrTaprootPrecompile<R>>,
-
-	)>;
+	),
+>;
 
 pub type PcallSchnorrSr25519 = SchnorrSr25519PrecompileCall<Runtime>;
 

--- a/precompiles/verify-schnorr-signatures/src/tests.rs
+++ b/precompiles/verify-schnorr-signatures/src/tests.rs
@@ -1,0 +1,46 @@
+// This file is part of Tangle.
+// Copyright (C) 2022-2024 Webb Technologies Inc.
+//
+// Tangle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Tangle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Tangle.  If not, see <http://www.gnu.org/licenses/>.
+
+use crate::mock::*;
+use precompile_utils::testing::*;
+use sp_core::{sr25519, Pair, H160};
+
+fn precompiles() -> Precompiles<Runtime> {
+	PrecompilesValue::get()
+}
+
+#[test]
+fn signature_verification_works_sr25519_schnorr() {
+	ExtBuilder::default().build().execute_with(|| {
+		let pair = sr25519::Pair::from_seed(b"12345678901234567890123456789012");
+		let public = pair.public();
+		let message = b"hello world";
+		let signature = pair.sign(message);
+
+		precompiles()
+			.prepare_test(
+				TestAccount::Alex,
+				H160::from_low_u64_be(1),
+				PcallSchnorrSr25519::verify {
+					public_bytes: public.0.to_vec().into(),
+					signature_bytes: signature.0.to_vec().into(),
+					message: message.into(),
+				},
+			)
+			.expect_no_logs()
+			.execute_returns(false);
+	});
+}

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -139,6 +139,7 @@ pallet-evm-precompile-verify-ecdsa-secp256k1-signature = { workspace = true }
 pallet-evm-precompile-verify-ecdsa-secp256r1-signature = { workspace = true }
 pallet-evm-precompile-verify-ecdsa-stark-signature = { workspace = true }
 pallet-evm-precompile-verify-schnorr-signatures = { workspace = true }
+pallet-evm-precompile-verify-bls381-signature = { workspace = true }
 
 precompile-utils = { workspace = true }
 
@@ -304,6 +305,7 @@ std = [
   "pallet-evm-precompile-verify-ecdsa-secp256r1-signature/std",
   "pallet-evm-precompile-verify-ecdsa-stark-signature/std",
   "pallet-evm-precompile-verify-schnorr-signatures/std",
+  "pallet-evm-precompile-verify-bls381-signature/std",
 
 
   # Sygma

--- a/runtime/testnet/Cargo.toml
+++ b/runtime/testnet/Cargo.toml
@@ -138,6 +138,7 @@ pallet-evm-precompile-vesting = { workspace = true }
 pallet-evm-precompile-verify-ecdsa-secp256k1-signature = { workspace = true }
 pallet-evm-precompile-verify-ecdsa-secp256r1-signature = { workspace = true }
 pallet-evm-precompile-verify-ecdsa-stark-signature = { workspace = true }
+pallet-evm-precompile-verify-schnorr-signatures = { workspace = true }
 
 precompile-utils = { workspace = true }
 
@@ -302,6 +303,7 @@ std = [
   "pallet-evm-precompile-verify-ecdsa-secp256k1-signature/std",
   "pallet-evm-precompile-verify-ecdsa-secp256r1-signature/std",
   "pallet-evm-precompile-verify-ecdsa-stark-signature/std",
+  "pallet-evm-precompile-verify-schnorr-signatures/std",
 
 
   # Sygma

--- a/runtime/testnet/src/precompiles.rs
+++ b/runtime/testnet/src/precompiles.rs
@@ -28,6 +28,7 @@ use pallet_evm_precompile_staking::StakingPrecompile;
 use pallet_evm_precompile_verify_ecdsa_secp256k1_signature::EcdsaSecp256k1Precompile;
 use pallet_evm_precompile_verify_ecdsa_secp256r1_signature::EcdsaSecp256r1Precompile;
 use pallet_evm_precompile_verify_ecdsa_stark_signature::EcdsaStarkPrecompile;
+use pallet_evm_precompile_verify_schnorr_signatures::*;
 use pallet_evm_precompile_vesting::VestingPrecompile;
 
 use precompile_utils::precompile_set::{
@@ -139,6 +140,54 @@ pub type WebbPrecompilesAt<R> = (
 	PrecompileAt<
 		AddressU64<2072>,
 		EcdsaStarkPrecompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-Sr25519 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2073>,
+		SchnorrSr25519Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-Secp256k1 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2074>,
+		SchnorrSecp256k1Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-Ed25519 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2075>,
+		SchnorrEd25519Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-Ed448 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2076>,
+		SchnorrEd448Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-P256 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2077>,
+		SchnorrP256Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-P384 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2078>,
+		SchnorrP384Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-Ristretto255 signature verifier precompile
+	PrecompileAt<
+		AddressU64<2079>,
+		SchnorrRistretto255Precompile<R>,
+		(CallableByContract, CallableByPrecompile),
+	>,
+	// Schnorr-Taproot signature verifier precompile
+	PrecompileAt<
+		AddressU64<2080>,
+		SchnorrTaprootPrecompile<R>,
 		(CallableByContract, CallableByPrecompile),
 	>,
 );

--- a/runtime/testnet/src/precompiles.rs
+++ b/runtime/testnet/src/precompiles.rs
@@ -25,6 +25,7 @@ use pallet_evm_precompile_registry::PrecompileRegistry;
 use pallet_evm_precompile_sha3fips::Sha3FIPS256;
 use pallet_evm_precompile_simple::{ECRecover, ECRecoverPublicKey, Identity, Ripemd160, Sha256};
 use pallet_evm_precompile_staking::StakingPrecompile;
+use pallet_evm_precompile_verify_bls381_signature::Bls381Precompile;
 use pallet_evm_precompile_verify_ecdsa_secp256k1_signature::EcdsaSecp256k1Precompile;
 use pallet_evm_precompile_verify_ecdsa_secp256r1_signature::EcdsaSecp256r1Precompile;
 use pallet_evm_precompile_verify_ecdsa_stark_signature::EcdsaStarkPrecompile;
@@ -190,6 +191,8 @@ pub type WebbPrecompilesAt<R> = (
 		SchnorrTaprootPrecompile<R>,
 		(CallableByContract, CallableByPrecompile),
 	>,
+	// Bls12-381 signature verifier precompile
+	PrecompileAt<AddressU64<2081>, Bls381Precompile<R>, (CallableByContract, CallableByPrecompile)>,
 );
 
 pub type WebbPrecompiles<R> = PrecompileSetBuilder<


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:

- [x]  Precompile to verify `Bls-381` Signature
- [x] Precompile to verify `Schnorr-Sr25519` Signature
- [x] Precompile to verify  `Schnorr-Secp256k1` Signature
- [x] Precompile to verify `Schnorr-Ed25519` Signature
- [x] Precompile to verify `Schnorr-Ed448`  Signature
- [x] Precompile to verify `Schnorr-P256` Signature
- [x] Precompile to verify `Schnorr-P384` Signature
- [x] Precompile to verify  `Schnorr-Ristretto255` Signature
- [x] Precompile to verify  `Schnorr-Taproot` Signature
- [x] Add precompiles to testnet runtime





**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #653 
