### PR TITLE
chore: update local ss58 prefix

### DIFF
--- a/node/src/chainspec/testnet.rs
+++ b/node/src/chainspec/testnet.rs
@@ -33,7 +33,10 @@ use sp_runtime::{
 	BoundedVec,
 };
 use std::{collections::BTreeMap, str::FromStr};
-use tangle_primitives::types::{BlockNumber, Signature};
+use tangle_primitives::{
+	types::{BlockNumber, Signature},
+	TESTNET_LOCAL_SS58_PREFIX,
+};
 use tangle_testnet_runtime::{
 	AccountId, BabeConfig, Balance, BalancesConfig, ClaimsConfig, CouncilConfig, EVMChainIdConfig,
 	EVMConfig, ImOnlineConfig, MaxVestingSchedules, Perbill, Precompiles, RoleKeyId,
@@ -166,7 +169,7 @@ pub fn local_testnet_config(chain_id: u64) -> Result<ChainSpec, String> {
 	let mut properties = sc_chain_spec::Properties::new();
 	properties.insert("tokenSymbol".into(), "tTNT".into());
 	properties.insert("tokenDecimals".into(), 18u32.into());
-	properties.insert("ss58Format".into(), 42.into());
+	properties.insert("ss58Format".into(), TESTNET_LOCAL_SS58_PREFIX.into());
 	#[allow(deprecated)]
 	Ok(ChainSpec::from_genesis(
 		// Name

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -75,7 +75,7 @@ impl SubstrateCli for Cli {
 	fn load_spec(&self, id: &str) -> Result<Box<dyn sc_service::ChainSpec>, String> {
 		Ok(match id {
 			"" | "dev" | "local" => Box::new(chainspec::testnet::local_testnet_config(
-				tangle_primitives::TESTNET_CHAIN_ID,
+				tangle_primitives::TESTNET_LOCAL_CHAIN_ID,
 			)?),
 			// generates the spec for benchmarking.
 			"benchmark" => Box::new(chainspec::testnet::local_benchmarking_config(

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -321,7 +321,12 @@ pub use sp_consensus_babe::AuthorityId as BabeId;
 pub const MAINNET_SS58_PREFIX: u16 = 5845;
 pub const MAINNET_CHAIN_ID: u64 = MAINNET_SS58_PREFIX as u64;
 
-// 3799 this would give us addresses with  tt prefix for testnet like
+// 3799 this would give us addresses with tt prefix for testnet like
 // ttFELSU4MTyzpfsgZ9tFinrmox7pV7nF1BLbfYjsu4rfDYM74
 pub const TESTNET_SS58_PREFIX: u16 = 3799;
 pub const TESTNET_CHAIN_ID: u64 = TESTNET_SS58_PREFIX as u64;
+
+// 3287 this would give us addresses with tt prefix for testnet like
+// ttFELSU4MTyzpfsgZ9tFinrmox7pV7nF1BLbfYjsu4rfDYM74
+pub const TESTNET_LOCAL_SS58_PREFIX: u16 = 3287;
+pub const TESTNET_LOCAL_CHAIN_ID: u64 = TESTNET_LOCAL_SS58_PREFIX as u64;


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Update the local testnet chain id to be different from the live testnet chain id.