### PR TITLE
Publish Tangle subxt to crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14633,16 +14633,11 @@ dependencies = [
 name = "tangle-subxt"
 version = "0.1.4"
 dependencies = [
- "hex",
  "parity-scale-codec 3.6.12",
  "scale-info",
  "serde",
- "sp-core",
- "sp-io",
  "subxt",
  "subxt-signer",
- "tangle-crypto-primitives",
- "tokio",
 ]
 
 [[package]]

--- a/tangle-subxt/Cargo.toml
+++ b/tangle-subxt/Cargo.toml
@@ -9,6 +9,8 @@ license = { workspace = true }
 repository = { workspace = true }
 keywards = ["blockchain", "tangle", "subxt"]
 categories = ["cryptography", "cryptography::cryptocurrencies"]
+exclude = ["./metadata"]
+readme = "README.md"
 
 [dependencies]
 parity-scale-codec = { workspace = true }

--- a/tangle-subxt/Cargo.toml
+++ b/tangle-subxt/Cargo.toml
@@ -18,11 +18,3 @@ scale-info = { workspace = true }
 subxt = { version = "0.37.0", default-features = false, features = ["jsonrpsee", "native"] }
 subxt-signer = { version = "0.37.0", default-features = false, features = ["subxt", "sr25519", "ecdsa", "std"] }
 serde = { workspace = true, features = ["derive"] }
-
-[dev-dependencies]
-sp-core = { workspace = true }
-sp-io = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-tangle-crypto-primitives = { path = "../primitives/crypto"}
-hex = { workspace = true }
-

--- a/tangle-subxt/Cargo.toml
+++ b/tangle-subxt/Cargo.toml
@@ -1,11 +1,14 @@
 [package]
 name = "tangle-subxt"
 version = "0.1.4"
+description = "Rust bindings and interface to interact with Tangle Network using subxt"
 authors = { workspace = true }
 edition = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }
+keywards = ["blockchain", "tangle", "subxt"]
+categories = ["cryptography", "cryptography::cryptocurrencies"]
 
 [dependencies]
 parity-scale-codec = { workspace = true }


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Published [tangle-subxt](https://crates.io/crates/tangle-subxt) to crates.io
- added [`@webb-tools/webb-devs`] team to it, so anyone in that team could publish new versions.



**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes 
