### PR TITLE
Use nextest in CI

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,3 @@
+[profile.ci]
+failure-output = "immediate-final"
+fail-fast = false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,6 +29,9 @@ jobs:
         run: cargo fmt --all -- --check
 
   test:
+    env:
+      CARGO_TERM_COLOR: always
+
     concurrency:
       group: test-${{ github.ref }}
       cancel-in-progress: true
@@ -46,10 +49,9 @@ jobs:
           target: wasm32-unknown-unknown
 
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-nextest
-          version: latest
+          tool: nextest
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v1.3.0
@@ -58,7 +60,7 @@ jobs:
         run: sudo apt-get install protobuf-compiler
 
       - name: Run test suite
-        run: cargo test
+        run: cargo nextest run --profile ci
 
   clippy:
     concurrency:


### PR DESCRIPTION
**Summary of changes**
Changes introduced in this pull request:
- Before, `nextest` was being installed but never used. I set it up with their recommendations for CI: https://nexte.st/#features



**Reference issue to close (if applicable)**
