### PR TITLE
feat!: Select Assets when requesting a service

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
           packages = [
             pkgs.taplo
             pkgs.cargo-nextest
+            pkgs.cargo-tarpaulin
           ];
           # Environment variables
           RUST_SRC_PATH = "${toolchain}/lib/rustlib/src/rust/library";

--- a/pallets/services/rpc/runtime-api/src/lib.rs
+++ b/pallets/services/rpc/runtime-api/src/lib.rs
@@ -27,10 +27,11 @@ pub type BlockNumberOf<Block> =
 	<<Block as sp_runtime::traits::HeaderProvider>::HeaderT as sp_runtime::traits::Header>::Number;
 
 sp_api::decl_runtime_apis! {
-	pub trait ServicesApi<C, AccountId>
+	pub trait ServicesApi<C, AccountId, AssetId>
 	where
 		C: Constraints,
 		AccountId: Codec + MaybeDisplay + Serialize,
+		AssetId: Codec + MaybeDisplay + Serialize,
 	{
 		/// Query all the services that this operator is providing along with their blueprints.
 		///
@@ -41,7 +42,7 @@ sp_api::decl_runtime_apis! {
 		fn query_services_with_blueprints_by_operator(
 			operator: AccountId,
 		) -> Result<
-			Vec<RpcServicesWithBlueprint<C, AccountId, BlockNumberOf<Block>>>,
+			Vec<RpcServicesWithBlueprint<C, AccountId, BlockNumberOf<Block>, AssetId>>,
 			sp_runtime::DispatchError,
 		>;
 	}

--- a/pallets/services/rpc/src/lib.rs
+++ b/pallets/services/rpc/src/lib.rs
@@ -36,18 +36,19 @@ type BlockNumberOf<Block> =
 
 /// ServicesClient RPC methods.
 #[rpc(client, server)]
-pub trait ServicesApi<BlockHash, X, AccountId, BlockNumber>
+pub trait ServicesApi<BlockHash, X, AccountId, BlockNumber, AssetId>
 where
 	X: Constraints,
 	AccountId: Codec + MaybeDisplay + core::fmt::Debug + Send + Sync + 'static + Serialize,
 	BlockNumber: Codec + MaybeDisplay + core::fmt::Debug + Send + Sync + 'static + Serialize,
+	AssetId: Codec + MaybeDisplay + core::fmt::Debug + Send + Sync + 'static + Serialize,
 {
 	#[method(name = "services_queryServicesWithBlueprintsByOperator")]
 	fn query_services_with_blueprints_by_operator(
 		&self,
 		operator: AccountId,
 		at: Option<BlockHash>,
-	) -> RpcResult<Vec<RpcServicesWithBlueprint<X, AccountId, BlockNumber>>>;
+	) -> RpcResult<Vec<RpcServicesWithBlueprint<X, AccountId, BlockNumber, AssetId>>>;
 }
 
 /// A struct that implements the `ServicesApi`.
@@ -63,21 +64,22 @@ impl<C, M, P> ServicesClient<C, M, P> {
 	}
 }
 
-impl<C, X, Block, AccountId>
-	ServicesApiServer<<Block as BlockT>::Hash, X, AccountId, BlockNumberOf<Block>>
+impl<C, X, Block, AccountId, AssetId>
+	ServicesApiServer<<Block as BlockT>::Hash, X, AccountId, BlockNumberOf<Block>, AssetId>
 	for ServicesClient<C, Block, AccountId>
 where
 	Block: BlockT,
 	AccountId: Codec + MaybeDisplay + core::fmt::Debug + Send + Sync + 'static + Serialize,
+	AssetId: Codec + MaybeDisplay + core::fmt::Debug + Send + Sync + 'static + Serialize,
 	X: Constraints,
 	C: HeaderBackend<Block> + ProvideRuntimeApi<Block> + Send + Sync + 'static,
-	C::Api: ServicesRuntimeApi<Block, X, AccountId>,
+	C::Api: ServicesRuntimeApi<Block, X, AccountId, AssetId>,
 {
 	fn query_services_with_blueprints_by_operator(
 		&self,
 		operator: AccountId,
 		at: Option<<Block as BlockT>::Hash>,
-	) -> RpcResult<Vec<RpcServicesWithBlueprint<X, AccountId, BlockNumberOf<Block>>>> {
+	) -> RpcResult<Vec<RpcServicesWithBlueprint<X, AccountId, BlockNumberOf<Block>, AssetId>>> {
 		let api = self.client.runtime_api();
 		let at = at.unwrap_or_else(|| self.client.info().best_hash);
 

--- a/pallets/services/src/impls.rs
+++ b/pallets/services/src/impls.rs
@@ -69,6 +69,8 @@ impl<T: Config> Constraints for types::ConstraintsOf<T> {
 	type MaxContainerImageNameLength = T::MaxContainerImageNameLength;
 
 	type MaxContainerImageTagLength = T::MaxContainerImageTagLength;
+
+	type MaxAssetsPerService = T::MaxAssetsPerService;
 }
 
 impl traits::EvmGasWeightMapping for () {

--- a/pallets/services/src/lib.rs
+++ b/pallets/services/src/lib.rs
@@ -824,8 +824,6 @@ pub mod module {
 					BoundedVec::<_, MaxOperatorsPerServiceOf<T>>::try_from(operators)
 						.map_err(|_| Error::<T>::MaxServiceProvidersExceeded)?;
 
-				let assets = BoundedVec::<_, MaxAssetsPerServiceOf<T>>::try_from(assets)
-					.map_err(|_| Error::<T>::MaxAssetsPerServiceExceeded)?;
 				let service_request = ServiceRequest {
 					blueprint: blueprint_id,
 					owner: caller.clone(),

--- a/pallets/services/src/lib.rs
+++ b/pallets/services/src/lib.rs
@@ -59,6 +59,7 @@ pub mod module {
 	use super::*;
 	use frame_support::dispatch::PostDispatchInfo;
 	use sp_core::{H160, H256};
+	use sp_runtime::traits::{AtLeast32BitUnsigned, MaybeSerializeDeserialize};
 	use sp_std::vec::Vec;
 	use tangle_primitives::{
 		services::{PriceTargets, *},
@@ -85,6 +86,16 @@ pub mod module {
 		/// A type that implements the `EvmGasWeightMapping` trait for the conversion of EVM gas to
 		/// Substrate weight and vice versa.
 		type EvmGasWeightMapping: traits::EvmGasWeightMapping;
+
+		/// The asset ID type.
+		type AssetId: AtLeast32BitUnsigned
+			+ Parameter
+			+ Member
+			+ MaybeSerializeDeserialize
+			+ Clone
+			+ Copy
+			+ PartialOrd
+			+ MaxEncodedLen;
 
 		/// Maximum number of fields in a job call.
 		#[pallet::constant]
@@ -143,6 +154,9 @@ pub mod module {
 		/// Container image tag maximum length.
 		#[pallet::constant]
 		type MaxContainerImageTagLength: Get<u32> + Default + Parameter + MaybeSerializeDeserialize;
+		/// Maximum number of assets per service.
+		#[pallet::constant]
+		type MaxAssetsPerService: Get<u32> + Default + Parameter + MaybeSerializeDeserialize;
 
 		/// The constraints for the service module.
 		/// use [crate::types::ConstraintsOf] with `Self` to implement this trait.
@@ -208,6 +222,10 @@ pub mod module {
 		MaxServicesPerProviderExceeded,
 		/// The operator is not active, ensure operator status is ACTIVE in multi-asset-delegation
 		OperatorNotActive,
+		/// No assets provided for the service, at least one asset is required.
+		NoAssetsProvided,
+		/// The maximum number of assets per service has been exceeded.
+		MaxAssetsPerServiceExceeded,
 	}
 
 	#[pallet::event]
@@ -278,6 +296,8 @@ pub mod module {
 			pending_approvals: Vec<T::AccountId>,
 			/// The list of operators that atomaticaly approved the service.
 			approved: Vec<T::AccountId>,
+			/// The list of asset IDs that are being used to secure the service.
+			assets: Vec<T::AssetId>,
 		},
 		/// A service request has been approved.
 		ServiceRequestApproved {
@@ -325,6 +345,8 @@ pub mod module {
 			service_id: u64,
 			/// The ID of the service blueprint.
 			blueprint_id: u64,
+			/// The list of asset IDs that are being used to secure the service.
+			assets: Vec<T::AssetId>,
 		},
 
 		/// A service has been terminated.
@@ -436,7 +458,7 @@ pub mod module {
 		_,
 		Identity,
 		u64,
-		ServiceRequest<T::Constraints, T::AccountId, BlockNumberFor<T>>,
+		ServiceRequest<T::Constraints, T::AccountId, BlockNumberFor<T>, T::AssetId>,
 		ResultQuery<Error<T>::ServiceRequestNotFound>,
 	>;
 
@@ -448,7 +470,7 @@ pub mod module {
 		_,
 		Identity,
 		u64,
-		Service<T::Constraints, T::AccountId, BlockNumberFor<T>>,
+		Service<T::Constraints, T::AccountId, BlockNumberFor<T>, T::AssetId>,
 		ResultQuery<Error<T>::ServiceNotFound>,
 	>;
 
@@ -710,14 +732,18 @@ pub mod module {
 			#[pallet::compact] blueprint_id: u64,
 			permitted_callers: Vec<T::AccountId>,
 			service_providers: Vec<T::AccountId>,
-			#[pallet::compact] ttl: BlockNumberFor<T>,
 			request_args: Vec<Field<T::Constraints, T::AccountId>>,
+			assets: Vec<T::AssetId>,
+			#[pallet::compact] ttl: BlockNumberFor<T>,
 		) -> DispatchResultWithPostInfo {
 			// TODO(@shekohex): split this function into smaller functions.
 			let caller = ensure_signed(origin)?;
 			let (_, blueprint) = Self::blueprints(blueprint_id)?;
 
 			blueprint.type_check_request(&request_args).map_err(Error::<T>::TypeCheck)?;
+			// ensure we at least have one asset
+			ensure!(!assets.is_empty(), Error::<T>::NoAssetsProvided);
+
 			let mut preferences = Vec::new();
 			let mut pending_approvals = Vec::new();
 			let mut approved = Vec::new();
@@ -740,6 +766,8 @@ pub mod module {
 			let permitted_callers =
 				BoundedVec::<_, MaxPermittedCallersOf<T>>::try_from(permitted_callers)
 					.map_err(|_| Error::<T>::MaxPermittedCallersExceeded)?;
+			let assets = BoundedVec::<_, MaxAssetsPerServiceOf<T>>::try_from(assets)
+				.map_err(|_| Error::<T>::MaxAssetsPerServiceExceeded)?;
 			if pending_approvals.is_empty() {
 				// No approval is required, initiate the service immediately.
 				for operator in &approved {
@@ -757,6 +785,7 @@ pub mod module {
 					id: service_id,
 					blueprint: blueprint_id,
 					owner: caller.clone(),
+					assets: assets.clone(),
 					permitted_callers,
 					operators,
 					ttl,
@@ -774,6 +803,7 @@ pub mod module {
 					request_id: None,
 					service_id,
 					blueprint_id,
+					assets: assets.to_vec(),
 				});
 
 				// TODO: add weight for the request to the total weight.
@@ -793,9 +823,13 @@ pub mod module {
 				let operators_with_approval_state =
 					BoundedVec::<_, MaxOperatorsPerServiceOf<T>>::try_from(operators)
 						.map_err(|_| Error::<T>::MaxServiceProvidersExceeded)?;
+
+				let assets = BoundedVec::<_, MaxAssetsPerServiceOf<T>>::try_from(assets)
+					.map_err(|_| Error::<T>::MaxAssetsPerServiceExceeded)?;
 				let service_request = ServiceRequest {
 					blueprint: blueprint_id,
 					owner: caller.clone(),
+					assets: assets.clone(),
 					ttl,
 					args,
 					permitted_callers,
@@ -810,6 +844,7 @@ pub mod module {
 					blueprint_id,
 					pending_approvals,
 					approved,
+					assets: assets.to_vec(),
 				});
 
 				// TODO: add weight for the request to the total weight.
@@ -879,6 +914,7 @@ pub mod module {
 					id: service_id,
 					blueprint: request.blueprint,
 					owner: request.owner.clone(),
+					assets: request.assets.clone(),
 					permitted_callers: request.permitted_callers.clone(),
 					operators,
 					ttl: request.ttl,
@@ -895,6 +931,7 @@ pub mod module {
 				Self::deposit_event(Event::ServiceInitiated {
 					owner: request.owner,
 					request_id: Some(request_id),
+					assets: request.assets.to_vec(),
 					service_id,
 					blueprint_id: request.blueprint,
 				});

--- a/pallets/services/src/mock.rs
+++ b/pallets/services/src/mock.rs
@@ -219,11 +219,13 @@ impl EvmGasWeightMapping for PalletEVMGasWeightMapping {
 	}
 }
 
+pub type AssetId = u32;
+
 pub struct MockDelegationManager;
 impl tangle_primitives::traits::MultiAssetDelegationInfo<AccountId, Balance>
 	for MockDelegationManager
 {
-	type AssetId = u32;
+	type AssetId = AssetId;
 
 	fn get_current_round() -> tangle_primitives::types::RoundIndex {
 		Default::default()
@@ -329,6 +331,10 @@ parameter_types! {
 	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 	pub const MaxContainerImageTagLength: u32 = 1024;
+
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub const MaxAssetsPerService: u32 = 64;
 }
 
 impl Config for Runtime {
@@ -336,6 +342,7 @@ impl Config for Runtime {
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type Currency = Balances;
 	type PalletId = ServicesPalletId;
+	type AssetId = AssetId;
 	type EvmRunner = MockedEvmRunner;
 	type EvmGasWeightMapping = PalletEVMGasWeightMapping;
 	type MaxFields = MaxFields;
@@ -357,6 +364,7 @@ impl Config for Runtime {
 	type MaxContainerRegistryLength = MaxContainerRegistryLength;
 	type MaxContainerImageNameLength = MaxContainerImageNameLength;
 	type MaxContainerImageTagLength = MaxContainerImageTagLength;
+	type MaxAssetsPerService = MaxAssetsPerService;
 	type Constraints = pallet_services::types::ConstraintsOf<Self>;
 	type OperatorDelegationManager = MockDelegationManager;
 	type WeightInfo = ();

--- a/pallets/services/src/rpc.rs
+++ b/pallets/services/src/rpc.rs
@@ -10,7 +10,7 @@ impl<T: Config> Pallet<T> {
 	pub fn services_with_blueprints_by_operator(
 		operator: T::AccountId,
 	) -> Result<
-		Vec<RpcServicesWithBlueprint<T::Constraints, T::AccountId, BlockNumberFor<T>>>,
+		Vec<RpcServicesWithBlueprint<T::Constraints, T::AccountId, BlockNumberFor<T>, T::AssetId>>,
 		Error<T>,
 	> {
 		let profile = Self::operator_profile(operator)?;

--- a/pallets/services/src/types.rs
+++ b/pallets/services/src/types.rs
@@ -30,6 +30,8 @@ pub type MaxFieldsOf<T> = <ConstraintsFor<T> as Constraints>::MaxFields;
 
 pub type MaxOperatorsPerServiceOf<T> = <ConstraintsFor<T> as Constraints>::MaxOperatorsPerService;
 
+pub type MaxAssetsPerServiceOf<T> = <ConstraintsFor<T> as Constraints>::MaxAssetsPerService;
+
 /// Extract the constraints from the runtime.
 #[derive(RuntimeDebugNoBound, CloneNoBound, Encode, Decode, TypeInfo, MaxEncodedLen)]
 #[scale_info(skip_type_params(T))]

--- a/precompiles/services/Services.sol
+++ b/precompiles/services/Services.sol
@@ -21,10 +21,11 @@ interface ServicesPrecompile {
 
     /// @notice Request a service from a specific blueprint
     /// @param blueprint_id The ID of the blueprint
+    /// @param assets The list of assets to use for the service
     /// @param permitted_callers_data The permitted callers for the service encoded as bytes
     /// @param service_providers_data The service providers encoded as bytes
     /// @param request_args_data The request arguments encoded as bytes
-    function requestService(uint256 blueprint_id, bytes calldata permitted_callers_data, bytes calldata service_providers_data, bytes calldata request_args_data) external;
+    function requestService(uint256 blueprint_id, uint256[] assets, bytes calldata permitted_callers_data, bytes calldata service_providers_data, bytes calldata request_args_data) external;
 
     /// @notice Terminate a service
     /// @param service_id The ID of the service to terminate

--- a/precompiles/services/src/lib.rs
+++ b/precompiles/services/src/lib.rs
@@ -97,10 +97,11 @@ where
 	}
 
 	/// Request a new service.
-	#[precompile::public("requestService(uint256,bytes,bytes,bytes)")]
+	#[precompile::public("requestService(uint256,uint256[],bytes,bytes,bytes)")]
 	fn request_service(
 		handle: &mut impl PrecompileHandle,
 		blueprint_id: U256,
+		assets: Vec<U256>,
 		permitted_callers_data: UnboundedBytes,
 		service_providers_data: UnboundedBytes,
 		request_args_data: UnboundedBytes,
@@ -124,12 +125,15 @@ where
 		let request_args: Vec<Field<Runtime::Constraints, Runtime::AccountId>> =
 			Decode::decode(&mut &request_args_data[..])
 				.map_err(|_| revert("Invalid request arguments data"))?;
+		let assets: Vec<Runtime::AssetId> =
+			assets.into_iter().map(|asset| asset.as_u32().into()).collect();
 
 		let call = pallet_services::Call::<Runtime>::request {
 			blueprint_id,
 			permitted_callers,
 			service_providers,
 			ttl: 10000_u32.into(),
+			assets,
 			request_args,
 		};
 

--- a/precompiles/services/src/mock.rs
+++ b/precompiles/services/src/mock.rs
@@ -334,11 +334,13 @@ impl From<TestAccount> for sp_core::sr25519::Public {
 	}
 }
 
+pub type AssetId = u32;
+
 pub struct MockDelegationManager;
 impl tangle_primitives::traits::MultiAssetDelegationInfo<AccountId, Balance>
 	for MockDelegationManager
 {
-	type AssetId = u32;
+	type AssetId = AssetId;
 
 	fn get_current_round() -> tangle_primitives::types::RoundIndex {
 		Default::default()
@@ -444,12 +446,17 @@ parameter_types! {
 	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
 	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
 	pub const MaxContainerImageTagLength: u32 = 1024;
+
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo)]
+	#[cfg_attr(feature = "std", derive(serde::Serialize, serde::Deserialize))]
+	pub const MaxAssetsPerService: u32 = 164;
 }
 
 impl pallet_services::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 	type ForceOrigin = frame_system::EnsureRoot<AccountId>;
 	type Currency = Balances;
+	type AssetId = AssetId;
 	type PalletId = ServicesPalletId;
 	type EvmRunner = MockedEvmRunner;
 	type EvmGasWeightMapping = PalletEVMGasWeightMapping;
@@ -472,6 +479,7 @@ impl pallet_services::Config for Runtime {
 	type MaxContainerRegistryLength = MaxContainerRegistryLength;
 	type MaxContainerImageNameLength = MaxContainerImageNameLength;
 	type MaxContainerImageTagLength = MaxContainerImageTagLength;
+	type MaxAssetsPerService = MaxAssetsPerService;
 	type Constraints = pallet_services::types::ConstraintsOf<Self>;
 	type OperatorDelegationManager = MockDelegationManager;
 	type WeightInfo = ();

--- a/precompiles/services/src/tests.rs
+++ b/precompiles/services/src/tests.rs
@@ -26,6 +26,8 @@ fn zero_key() -> ecdsa::Public {
 	ecdsa::Public::from([0; 33])
 }
 
+const WETH: AssetId = 1;
+
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum MachineKind {
@@ -194,6 +196,7 @@ fn test_request_service() {
 					permitted_callers_data: UnboundedBytes::from(permitted_callers_data.encode()),
 					service_providers_data: UnboundedBytes::from(service_providers_data.encode()),
 					request_args_data: UnboundedBytes::from(request_args_data),
+					assets: [WETH].into_iter().map(Into::into).collect(),
 				},
 			)
 			.execute_returns(());
@@ -301,6 +304,7 @@ fn test_terminate_service() {
 					permitted_callers_data: UnboundedBytes::from(permitted_callers_data.encode()),
 					service_providers_data: UnboundedBytes::from(service_providers_data.encode()),
 					request_args_data: UnboundedBytes::from(request_args_data),
+					assets: [WETH].into_iter().map(Into::into).collect(),
 				},
 			)
 			.execute_returns(());

--- a/runtime/mainnet/src/lib.rs
+++ b/runtime/mainnet/src/lib.rs
@@ -1870,11 +1870,11 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl pallet_services_rpc_runtime_api::ServicesApi<Block, PalletServicesConstraints, AccountId> for Runtime {
+	impl pallet_services_rpc_runtime_api::ServicesApi<Block, PalletServicesConstraints, AccountId, AssetId> for Runtime {
 		fn query_services_with_blueprints_by_operator(
 			operator: AccountId,
 		) -> Result<
-			Vec<RpcServicesWithBlueprint<PalletServicesConstraints, AccountId, BlockNumberOf<Block>>>,
+			Vec<RpcServicesWithBlueprint<PalletServicesConstraints, AccountId, BlockNumberOf<Block>, AssetId>>,
 			sp_runtime::DispatchError,
 		> {
 			Services::services_with_blueprints_by_operator(operator).map_err(Into::into)

--- a/runtime/mainnet/src/tangle_services.rs
+++ b/runtime/mainnet/src/tangle_services.rs
@@ -117,6 +117,9 @@ parameter_types! {
 
 	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerImageTagLength: u32 = 1024;
+
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
+	pub const MaxAssetsPerService: u32 = 64;
 }
 
 pub type PalletServicesConstraints = pallet_services::types::ConstraintsOf<Runtime>;
@@ -128,6 +131,7 @@ impl pallet_services::Config for Runtime {
 	type PalletId = ServicesPalletId;
 	type EvmRunner = PalletEvmRunner;
 	type EvmGasWeightMapping = PalletEVMGasWeightMapping;
+	type AssetId = AssetId;
 	type MaxFields = MaxFields;
 	type MaxFieldsSize = MaxFieldsSize;
 	type MaxMetadataLength = MaxMetadataLength;
@@ -147,6 +151,7 @@ impl pallet_services::Config for Runtime {
 	type MaxContainerRegistryLength = MaxContainerRegistryLength;
 	type MaxContainerImageNameLength = MaxContainerImageNameLength;
 	type MaxContainerImageTagLength = MaxContainerImageTagLength;
+	type MaxAssetsPerService = MaxAssetsPerService;
 	type Constraints = PalletServicesConstraints;
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type OperatorDelegationManager = MultiAssetDelegation;

--- a/runtime/testnet/src/lib.rs
+++ b/runtime/testnet/src/lib.rs
@@ -1987,11 +1987,11 @@ impl_runtime_apis! {
 	// 	}
 	// }
 
-	impl pallet_services_rpc_runtime_api::ServicesApi<Block, PalletServicesConstraints, AccountId> for Runtime {
+	impl pallet_services_rpc_runtime_api::ServicesApi<Block, PalletServicesConstraints, AccountId, AssetId> for Runtime {
 		fn query_services_with_blueprints_by_operator(
 			operator: AccountId,
 		) -> Result<
-			Vec<RpcServicesWithBlueprint<PalletServicesConstraints, AccountId, BlockNumberOf<Block>>>,
+			Vec<RpcServicesWithBlueprint<PalletServicesConstraints, AccountId, BlockNumberOf<Block>, AssetId>>,
 			sp_runtime::DispatchError,
 		> {
 			Services::services_with_blueprints_by_operator(operator).map_err(Into::into)

--- a/runtime/testnet/src/tangle_services.rs
+++ b/runtime/testnet/src/tangle_services.rs
@@ -114,6 +114,9 @@ parameter_types! {
 
 	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
 	pub const MaxContainerImageTagLength: u32 = 1024;
+
+	#[derive(Default, Copy, Clone, Eq, PartialEq, RuntimeDebug, Encode, Decode, MaxEncodedLen, TypeInfo, Serialize, Deserialize)]
+	pub const MaxAssetsPerService: u32 = 64;
 }
 
 pub type PalletServicesConstraints = pallet_services::types::ConstraintsOf<Runtime>;
@@ -125,6 +128,7 @@ impl pallet_services::Config for Runtime {
 	type PalletId = ServicesPalletId;
 	type EvmRunner = PalletEvmRunner;
 	type EvmGasWeightMapping = PalletEVMGasWeightMapping;
+	type AssetId = AssetId;
 	type MaxFields = MaxFields;
 	type MaxFieldsSize = MaxFieldsSize;
 	type MaxMetadataLength = MaxMetadataLength;
@@ -144,6 +148,7 @@ impl pallet_services::Config for Runtime {
 	type MaxContainerRegistryLength = MaxContainerRegistryLength;
 	type MaxContainerImageNameLength = MaxContainerImageNameLength;
 	type MaxContainerImageTagLength = MaxContainerImageTagLength;
+	type MaxAssetsPerService = MaxAssetsPerService;
 	type Constraints = PalletServicesConstraints;
 	#[cfg(not(feature = "runtime-benchmarks"))]
 	type OperatorDelegationManager = MultiAssetDelegation;


### PR DESCRIPTION
**Summary of changes**

This pull request introduces support for adding assets in the services pallet by adding `AssetId` to various APIs and structures, and implementing constraints and validation for assets.

Changes introduced in this pull request:

### API and Trait Updates:
* Added `AssetId` to the `ServicesApi` trait and updated related method signatures in `pallets/services/rpc/runtime-api/src/lib.rs` and `pallets/services/rpc/src/lib.rs`. [[1]](diffhunk://#diff-04688388833aa6a1ce3103b4d232a243c3258a59dfe6554fd72048127bc8697bL30-R34) [[2]](diffhunk://#diff-04688388833aa6a1ce3103b4d232a243c3258a59dfe6554fd72048127bc8697bL44-R45) [[3]](diffhunk://#diff-5bf79853c5c7edd80d4b9c7f5f79603fe2acd7dd6cc813b0b5f75c7e0bf0c5feL39-R51) [[4]](diffhunk://#diff-5bf79853c5c7edd80d4b9c7f5f79603fe2acd7dd6cc813b0b5f75c7e0bf0c5feL66-R82)

### Struct and Type Modifications:
* Updated `ServiceRequest` and `Service` structs to include `assets` field, and added corresponding constraints and bounds in `primitives/src/services/mod.rs`. [[1]](diffhunk://#diff-4b7a1f80a459305ca0d4565b9ee1ed01c3b98e2f6be79751e2d2a306bbbdcd14L376-R380) [[2]](diffhunk://#diff-4b7a1f80a459305ca0d4565b9ee1ed01c3b98e2f6be79751e2d2a306bbbdcd14L390-R405) [[3]](diffhunk://#diff-4b7a1f80a459305ca0d4565b9ee1ed01c3b98e2f6be79751e2d2a306bbbdcd14L411-R417)
* Added `MaxAssetsPerService` type to `Constraints` trait and implemented it in `pallets/services/src/impls.rs` and `pallets/services/src/types.rs`. [[1]](diffhunk://#diff-3e90df541719de1b0afbeed757534cb2482c07b273b4bc43eecead2e49ae72d2R72-R73) [[2]](diffhunk://#diff-f95176b419f01f2553824bbbeae2e6ff0f3a87587f2635a2b8d05272be1dde98R33-R34) [[3]](diffhunk://#diff-4b7a1f80a459305ca0d4565b9ee1ed01c3b98e2f6be79751e2d2a306bbbdcd14R87-R88)

### Validation and Error Handling:
* Added validation to ensure at least one asset is provided and the number of assets does not exceed the maximum allowed in `pallets/services/src/lib.rs`. [[1]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234R225-R228) [[2]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234L713-R746) [[3]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234R769-R770)

### Event and Storage Updates:
* Modified events and storage to handle assets in `pallets/services/src/lib.rs`. [[1]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234R299-R300) [[2]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234R348-R349) [[3]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234L439-R461) [[4]](diffhunk://#diff-f0f95233cd9cfa07955625fdab20d0bcc22b38a1381ffbf102393faa5a628234L451-R473)

### Precompile Changes:
* Updated the `requestService` precompile function to include `assets` parameter in `precompiles/services/src/lib.rs` and `precompiles/services/Services.sol`. [[1]](diffhunk://#diff-bfc6bf03de5c2abb7ea8d1b5011e471725aef29b7f7e6492f0c363aaaebaf088R24-R28) [[2]](diffhunk://#diff-cc28c9671fee749443658eac09da22977040d652a9c9187f82399d6badcd9b51L100-R104) [[3]](diffhunk://#diff-cc28c9671fee749443658eac09da22977040d652a9c9187f82399d6badcd9b51R128-R136)

**Reference issue to close (if applicable)**
<!-- Include the issue reference this pull request is connected to -->
<!--(e.g. Closes #1)-->
Closes #774 